### PR TITLE
Activate Quiz (as Quizmaster)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem 'launchy'
   gem 'poltergeist'
   gem 'phantomjs', require: 'phantomjs/poltergeist'
+  gem 'redis_test'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,7 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redis (3.3.1)
+    redis_test (0.0.10)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -269,6 +270,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
   redis
+  redis_test
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -9,9 +9,5 @@
   this.App || (this.App = {});
 
   App.cable = ActionCable.createConsumer();
-  console.log('cable.js');
-  // console.log(this.App.cable.subscriptions.subscriptions[0].identifier);
 
 }).call(this);
-
-console.log('after cable.js');

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -9,6 +9,9 @@
   this.App || (this.App = {});
 
   App.cable = ActionCable.createConsumer();
-  console.log(this);
+  console.log('cable.js');
+  // console.log(this.App.cable.subscriptions.subscriptions[0].identifier);
 
 }).call(this);
+
+console.log('after cable.js');

--- a/app/assets/javascripts/cable.js
+++ b/app/assets/javascripts/cable.js
@@ -9,5 +9,6 @@
   this.App || (this.App = {});
 
   App.cable = ActionCable.createConsumer();
+  console.log(this);
 
 }).call(this);

--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -1,20 +1,25 @@
+console.log('quiz.js');
 App.cable.subscriptions.create("QuizChannel", {
     collection: function () {
+      console.log('collection');
+
         return $("#message");
     },
 
     connected: function () {
         // Called when the subscription is ready for use on the server
-        // console.log('Connected')
+        console.log('Connected');
         // return this.collection().append('We are connected');
     },
 
     disconnected: function () {
+      console.log('Disonnected');
         // Called when the subscription has been terminated by the server
     },
 
     received: function (data) {
         // Called when there's incoming data on the websocket for this channel
+        console.log('Received');
         return this.printMessage(data)
 
     },

--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -1,31 +1,23 @@
-console.log('quiz.js');
 App.cable.subscriptions.create("QuizChannel", {
     collection: function () {
-      console.log('collection');
-
         return $("#message");
     },
 
     connected: function () {
         // Called when the subscription is ready for use on the server
-        console.log('Connected');
-        // return this.collection().append('We are connected');
     },
 
     disconnected: function () {
-      console.log('Disonnected');
         // Called when the subscription has been terminated by the server
     },
 
     received: function (data) {
         // Called when there's incoming data on the websocket for this channel
-        console.log('Received');
         return this.printMessage(data)
 
     },
 
     printMessage: function(data) {
-        // console.log(message);
         return this.collection().html(
           "<p>" + data + "</p>"
         );

--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -5,7 +5,8 @@ App.cable.subscriptions.create("QuizChannel", {
 
     connected: function () {
         // Called when the subscription is ready for use on the server
-        //return this.collection().append('We are connected');
+        // console.log('Connected')
+        // return this.collection().append('We are connected');
     },
 
     disconnected: function () {
@@ -19,8 +20,9 @@ App.cable.subscriptions.create("QuizChannel", {
     },
 
     printMessage: function(data) {
-        var message = data.message;
-        console.log(message);
-        return this.collection().append("<p>" + message + "</p>");
+        // console.log(message);
+        return this.collection().html(
+          "<p>" + data + "</p>"
+        );
     }
 });

--- a/app/channels/quiz_channel.rb
+++ b/app/channels/quiz_channel.rb
@@ -2,6 +2,8 @@
 class QuizChannel < ApplicationCable::Channel
   def subscribed
     stream_from 'quiz_channel'
+    binding.pry
+    puts 'We are subscribing to QuizChannel'
   end
 
   def unsubscribed

--- a/app/channels/quiz_channel.rb
+++ b/app/channels/quiz_channel.rb
@@ -2,8 +2,6 @@
 class QuizChannel < ApplicationCable::Channel
   def subscribed
     stream_from 'quiz_channel'
-    binding.pry
-    puts 'We are subscribing to QuizChannel'
   end
 
   def unsubscribed

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -6,7 +6,6 @@ class Quizmaster::QuizzesController < ApplicationController
   end
 
   def start_quiz
-    # @quiz = Quiz.find(params[:format])
     @questions = @quiz.questions
     content = params[:message]
     broadcast_content(content)

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -1,11 +1,26 @@
 class Quizmaster::QuizzesController < ApplicationController
+  before_action :get_quiz, only: [:show, :start_quiz]
+
   def show
-    @quiz = Quiz.find(params[:id])
     @questions = @quiz.questions
   end
 
-  def broadcast_content
+  def start_quiz
+    # @quiz = Quiz.find(params[:format])
+    @questions = @quiz.questions
+    content = params[:message]
+    broadcast_content(content)
+    render :show
+  end
+
+  def broadcast_content(content)
     # This method will broadcast content to Team
-    # BroadcastQuizJob.perform_now('')
+    BroadcastQuizJob.perform_now(content)
+  end
+
+  private
+
+  def get_quiz
+    @quiz = Quiz.find(params[:id])
   end
 end

--- a/app/jobs/broadcast_quiz_job.rb
+++ b/app/jobs/broadcast_quiz_job.rb
@@ -3,5 +3,6 @@ class BroadcastQuizJob < ApplicationJob
 
   def perform(message)
     ActionCable.server.broadcast 'quiz_channel', message
+    binding.pry
   end
 end

--- a/app/jobs/broadcast_quiz_job.rb
+++ b/app/jobs/broadcast_quiz_job.rb
@@ -3,6 +3,5 @@ class BroadcastQuizJob < ApplicationJob
 
   def perform(message)
     ActionCable.server.broadcast 'quiz_channel', message
-    binding.pry
   end
 end

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -7,3 +7,4 @@
     = submit_tag 'Create Team'
 - else
   %p Welcome back team
+#message

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -8,3 +8,4 @@
 - else
   %p Welcome back team
 #message
+  Questions will appear here.

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -4,4 +4,20 @@
 .questions
   - @questions.each do |question|
     %h3= question.body
-    
+
+.activate_quiz
+  = form_tag '#', id: 'start_quiz', controller: :quizzes, action: :start_quiz, method: :post, remote: true do
+    = hidden_field_tag 'id', @quiz.id
+    = text_field_tag 'message'
+    = submit_tag 'Start the Quiz', id: 'start_button', onclick: 'showSuccess();'
+.quiz_started
+  %h3 You have started the quiz!
+
+:javascript
+  $(document).ready( function() {
+    $('.quiz_started').hide();
+    this.showSuccess = function() {
+      $('.activate_quiz').hide();
+      $('.quiz_started').show();
+    };
+  });

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -2,9 +2,9 @@ development:
   adapter: redis
   url: redis://localhost:6379/1
 
-
 test:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 production:
   adapter: redis

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -4,7 +4,7 @@ development:
 
 test:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: redis://localhost:9736
 
 production:
   adapter: redis

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # config.action_cable.allowed_request_origins = ["http://127.0.0.1"]
+  config.action_cable.disable_request_forgery_protection = true
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
   namespace :quizmaster do
     resources :quiz, controller: :quizzes, only: [:show]
+    post '/quiz/:id', controller: :quizzes, action: :start_quiz
   end
 
   resources :quiz, controller: :games, only: [:index, :show] do

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -45,14 +45,9 @@ Feature: As a Team
     Given I am on the quiz "landing" page
     And I enter the code for "Trivia"
     Then I should be on the quiz page for "Trivia"
-    And I fill in "team[name]" with "Awesome"
-    # Then I should see my text "Awesome"
     And I switch to a new window
     And I am on the quizmaster page for "Trivia"
     When I fill in "message" with "The Quiz begins!"
     And I click the "Start the Quiz" button
     And I switch to window "1"
-    And I refresh the page
-    # Then I should see my text "Awesome"
-    # And show me the page
     Then I should see "The Quiz begins!"

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -34,7 +34,10 @@ Feature: As a Team
 
 
   Scenario: Accessing two quizzes in separate windows
-    Given I am on the quiz page for "Trivia" within window "1"
-    And I open a new window
-    And I am on the quiz page for "Trivia 2" within window "2"
+    Given I am on the quiz page for "Trivia"
+    And I switch to a new window
+    And I am on the quiz page for "Trivia 2"
+    Then I should see "Trivia 2"
+    And I switch to window "1"
+    Then I should see "Trivia"
     Then I should have "2" active windows

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -46,12 +46,13 @@ Feature: As a Team
     And I enter the code for "Trivia"
     Then I should be on the quiz page for "Trivia"
     And I fill in "team[name]" with "Awesome"
-    Then I should see my text "Awesome"
+    # Then I should see my text "Awesome"
     And I switch to a new window
     And I am on the quizmaster page for "Trivia"
     When I fill in "message" with "The Quiz begins!"
     And I click the "Start the Quiz" button
     And I switch to window "1"
-    Then I should see my text "Awesome"
+    And I refresh the page
+    # Then I should see my text "Awesome"
     # And show me the page
     Then I should see "The Quiz begins!"

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -40,9 +40,11 @@ Feature: As a Team
     Then I should see "Trivia"
     Then I should have "2" active windows
 
-@action_cable
+  @action_cable
   Scenario: Receive initial Quiz welcome message
-    Given I am on the quiz page for "Trivia"
+    Given I am on the quiz "landing" page
+    And I enter the code for "Trivia"
+    Then I should be on the quiz page for "Trivia"
     And I fill in "team[name]" with "Awesome"
     Then I should see my text "Awesome"
     And I switch to a new window

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -1,4 +1,5 @@
-@javascript
+@javascript @action_cable
+
 Feature: As a Team
   in order to play Quizmaster
   I need to be able to access the Quiz interface.
@@ -40,7 +41,6 @@ Feature: As a Team
     Then I should see "Trivia"
     Then I should have "2" active windows
 
-  @action_cable
   Scenario: Receive initial Quiz welcome message
     Given I am on the quiz "landing" page
     And I enter the code for "Trivia"

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -43,10 +43,13 @@ Feature: As a Team
 @action_cable
   Scenario: Receive initial Quiz welcome message
     Given I am on the quiz page for "Trivia"
+    And I fill in "team[name]" with "Awesome"
+    Then I should see my text "Awesome"
     And I switch to a new window
     And I am on the quizmaster page for "Trivia"
     When I fill in "message" with "The Quiz begins!"
     And I click the "Start the Quiz" button
     And I switch to window "1"
+    Then I should see my text "Awesome"
     # And show me the page
     Then I should see "The Quiz begins!"

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -21,3 +21,11 @@ Feature: As a Team
     Then I should be on the quiz page for "Trivia"
     And I should see "Welcome to quiz: Trivia"
     And I should see "Welcome back team"
+
+  Scenario: Receive initial "Quiz is starting" message
+    Given there is a "team_id" cookie set to "1"
+    And I am on the quiz "landing" page
+    And I enter the code for "Trivia"
+    Then I should be on the quiz page for "Trivia"
+    # When the quizmaster starts the quiz
+    # Then I should see "The Quiz is starting!"     

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -30,8 +30,6 @@ Feature: As a Team
     Then I should be on the quiz page for "Trivia"
     # When the quizmaster starts the quiz
     # Then I should see "The Quiz is starting!"
-    And I should see "Welcome back team"
-
 
   Scenario: Accessing two quizzes in separate windows
     Given I am on the quiz page for "Trivia"
@@ -41,3 +39,11 @@ Feature: As a Team
     And I switch to window "1"
     Then I should see "Trivia"
     Then I should have "2" active windows
+
+  Scenario: Receive initial Quiz welcome message
+    Given I am on the quiz page for "Trivia" in window "1"
+    And I switch to a new window
+    And I am on the quizmaster page for "Trivia"
+    Then I should have "2" active windows
+    When I fill in "message" with "The Quiz begins!"
+    Then I should see "The Quiz begins!" within window "1"

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -5,6 +5,7 @@ Feature: As a Team
 
   Background:
     Given there is a quiz called "Trivia"
+    And there is a quiz called "Trivia 2"
 
   Scenario: Access quiz and subscribe to channel
     Given I am on the quiz "landing" page
@@ -32,8 +33,8 @@ Feature: As a Team
     And I should see "Welcome back team"
 
 
-  Scenario: Dealing with two windows
-    Given I am on the quiz "landing" page
-    And  I open a new window
-    And I am on the quiz page for "Trivia" within window "1"
+  Scenario: Accessing two quizzes in separate windows
+    Given I am on the quiz page for "Trivia" within window "1"
+    And I open a new window
+    And I am on the quiz page for "Trivia 2" within window "2"
     Then I should have "2" active windows

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -28,4 +28,12 @@ Feature: As a Team
     And I enter the code for "Trivia"
     Then I should be on the quiz page for "Trivia"
     # When the quizmaster starts the quiz
-    # Then I should see "The Quiz is starting!"     
+    # Then I should see "The Quiz is starting!"
+    And I should see "Welcome back team"
+
+
+  Scenario: Dealing with two windows
+    Given I am on the quiz "landing" page
+    And  I open a new window
+    And I am on the quiz page for "Trivia" within window "1"
+    Then I should have "2" active windows

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -40,10 +40,12 @@ Feature: As a Team
     Then I should see "Trivia"
     Then I should have "2" active windows
 
+@action_cable
   Scenario: Receive initial Quiz welcome message
-    Given I am on the quiz page for "Trivia" in window "1"
+    Given I am on the quiz page for "Trivia"
     And I switch to a new window
     And I am on the quizmaster page for "Trivia"
-    Then I should have "2" active windows
     When I fill in "message" with "The Quiz begins!"
-    Then I should see "The Quiz begins!" within window "1"
+    And I click the "Start the Quiz" button
+    And I switch to window "1"
+    Then I should see "The Quiz begins!"

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -48,4 +48,5 @@ Feature: As a Team
     When I fill in "message" with "The Quiz begins!"
     And I click the "Start the Quiz" button
     And I switch to window "1"
+    # And show me the page
     Then I should see "The Quiz begins!"

--- a/features/quizmaster/view_quiz_page.feature
+++ b/features/quizmaster/view_quiz_page.feature
@@ -6,9 +6,9 @@ Feature: As a Quizmaster
 Background:
   Given there is a quiz called "Trivia"
   And the following questions exist in "Trivia":
-  | body            | answer     |
-  | What is 2+2?    | Four       |
-  | Who is awesome? | Not Thomas |
+    | body            | answer     |
+    | What is 2+2?    | Four       |
+    | Who is awesome? | Not Thomas |
   And I am on the quiz page for "Trivia"
 
 Scenario: Viewing my quiz page

--- a/features/quizmaster/view_quiz_page.feature
+++ b/features/quizmaster/view_quiz_page.feature
@@ -8,9 +8,13 @@ Background:
   | body            | answer     |
   | What is 2+2?    | Four       |
   | Who is awesome? | Not Thomas |
+  And I am on the quiz page for "Trivia"
 
 Scenario: Viewing my quiz page
-  Given I am on the quiz page for "Trivia"
   Then I should see "Trivia"
   And I should see a quiz code
   And I should see "Who is awesome?"
+
+Scenario: Starting the quiz
+  When I click the "Start the Quiz" button
+  # Then I should send a message to Teams

--- a/features/quizmaster/view_quiz_page.feature
+++ b/features/quizmaster/view_quiz_page.feature
@@ -1,3 +1,4 @@
+@javascript @action_cable
 Feature: As a Quizmaster
   in order to give out my Quiz
   I need to generate a code where Players can access the Quiz.
@@ -11,11 +12,13 @@ Background:
   And I am on the quiz page for "Trivia"
 
 Scenario: Viewing my quiz page
-  Then I should see "Trivia"
-  And I should see a quiz code
-  And I should see "Who is awesome?"
+  Then I should see "Welcome to quiz: Trivia"
 
-@javascript
+
 Scenario: Starting the quiz
-  When I click the "Start the Quiz" button
-  # Then I should send a message to Teams
+  And I switch to a new window
+  And I am on the quizmaster page for "Trivia"
+  When I fill in "message" with "The Quiz begins!"
+  And I click the "Start the Quiz" button
+  And I switch to window "1"
+  Then I should see "The Quiz begins!"

--- a/features/quizmaster/view_quiz_page.feature
+++ b/features/quizmaster/view_quiz_page.feature
@@ -15,6 +15,7 @@ Scenario: Viewing my quiz page
   And I should see a quiz code
   And I should see "Who is awesome?"
 
+@javascript
 Scenario: Starting the quiz
   When I click the "Start the Quiz" button
   # Then I should send a message to Teams

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -9,3 +9,7 @@ end
 When(/^I click the "([^"]*)" button$/) do |button|
   click_link_or_button button
 end
+
+When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, content|
+  fill_in element, with: content
+end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -2,7 +2,10 @@ Then(/^I should see "([^"]*)"$/) do |content|
   expect(page).to have_content content
 end
 
-
 Then(/^show me the page$/) do
   save_and_open_page
+end
+
+When(/^I click the "([^"]*)" button$/) do |button|
+  click_link_or_button button
 end

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -16,7 +16,8 @@ Given(/^I am on the quiz page for "([^"]*)" in window "([^"]*)"$/) do |quiz, ind
   quiz = Quiz.find_by(name: quiz)
   switch_to_window(windows[index.to_i - 1])
   visit quiz_path(quiz)
-  expect(page).to have_content quiz.name
+
+
 end
 
 Then(/^I should see my text "([^"]*)"$/) do |text|
@@ -25,9 +26,19 @@ Then(/^I should see my text "([^"]*)"$/) do |text|
 end
 
 When(/^I refresh the page$/) do
-  page.evaluate_script("window.location.reload()")
+  #page.evaluate_script("window.location.reload()")
+  #binding.pry
 end
 
-# Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
-#   expect(windows[index.to_i - 1]).to have_content content
-# end
+Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
+  within_window(switch_to_window(windows[index.to_i - 1])) do
+    page.execute_script("App.cable.subscriptions.consumer.connection.close()")
+    page.execute_script("App.cable.subscriptions.create('QuizChannel')")
+    #sleep(0.01) until page.evaluate_script("App.cable.connection.getState() == 'open'")
+    #puts windows[index.to_i - 1].socket
+    #binding.pry
+    #sleep(0.01) until page.evaluate_script("App.cable.connection.getState() == 'open'")
+    sleep(3)
+    expect(page).to have_content content
+  end
+end

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -20,5 +20,8 @@ end
 
 Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
   switch_to_window(windows[index.to_i - 1])
+  # steps %{
+  #   Then show me the page
+  # }
   expect(page).to have_content content
 end

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -19,7 +19,7 @@ Given(/^I am on the quiz page for "([^"]*)" in window "([^"]*)"$/) do |quiz, ind
 end
 
 Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
-  switch_to_window(windows[index.to_i - 1])
+  # switch_to_window(windows[index.to_i - 1])
   # steps %{
   #   Then show me the page
   # }

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -19,5 +19,6 @@ Given(/^I am on the quiz page for "([^"]*)" in window "([^"]*)"$/) do |quiz, ind
 end
 
 Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
-  expect(windows[index.to_i - 1]).to have_content content
+  switch_to_window(windows[index.to_i - 1])
+  expect(page).to have_content content
 end

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -5,7 +5,7 @@ end
 
 Given(/^I switch to window "([^"]*)"$/) do |index|
   switch_to_window(windows[index.to_i - 1])
-  sleep(2)
+  # sleep(2)
 end
 
 Then(/^I should have "([^"]*)" active windows$/) do |count|
@@ -22,6 +22,10 @@ end
 Then(/^I should see my text "([^"]*)"$/) do |text|
   field = find_field('team[name]')
   expect(field.value).to eq text
+end
+
+When(/^I refresh the page$/) do
+  page.evaluate_script("window.location.reload()")
 end
 
 # Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -19,6 +19,11 @@ Given(/^I am on the quiz page for "([^"]*)" in window "([^"]*)"$/) do |quiz, ind
   expect(page).to have_content quiz.name
 end
 
-Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
-  expect(page).to have_content content
+Then(/^I should see my text "([^"]*)"$/) do |text|
+  field = find_field('team[name]')
+  expect(field.value).to eq text
 end
+
+# Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
+#   expect(windows[index.to_i - 1]).to have_content content
+# end

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -1,0 +1,23 @@
+Given(/^I switch to a new window$/) do
+  window = open_new_window
+  switch_to_window(window)
+end
+
+Given(/^I switch to window "([^"]*)"$/) do |index|
+  switch_to_window(windows[index.to_i - 1])
+end
+
+Then(/^I should have "([^"]*)" active windows$/) do |count|
+  expect(windows.count).to eq count.to_i
+end
+
+Given(/^I am on the quiz page for "([^"]*)" in window "([^"]*)"$/) do |quiz, index|
+  quiz = Quiz.find_by(name: quiz)
+  switch_to_window(windows[index.to_i - 1])
+  visit quiz_path(quiz)
+  expect(page).to have_content quiz.name
+end
+
+Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
+  expect(windows[index.to_i - 1]).to have_content content
+end

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -5,19 +5,10 @@ end
 
 Given(/^I switch to window "([^"]*)"$/) do |index|
   switch_to_window(windows[index.to_i - 1])
-  # sleep(2)
 end
 
 Then(/^I should have "([^"]*)" active windows$/) do |count|
   expect(windows.count).to eq count.to_i
-end
-
-Given(/^I am on the quiz page for "([^"]*)" in window "([^"]*)"$/) do |quiz, index|
-  quiz = Quiz.find_by(name: quiz)
-  switch_to_window(windows[index.to_i - 1])
-  visit quiz_path(quiz)
-
-
 end
 
 Then(/^I should see my text "([^"]*)"$/) do |text|
@@ -25,20 +16,4 @@ Then(/^I should see my text "([^"]*)"$/) do |text|
   expect(field.value).to eq text
 end
 
-When(/^I refresh the page$/) do
-  #page.evaluate_script("window.location.reload()")
-  #binding.pry
-end
 
-Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
-  within_window(switch_to_window(windows[index.to_i - 1])) do
-    page.execute_script("App.cable.subscriptions.consumer.connection.close()")
-    page.execute_script("App.cable.subscriptions.create('QuizChannel')")
-    #sleep(0.01) until page.evaluate_script("App.cable.connection.getState() == 'open'")
-    #puts windows[index.to_i - 1].socket
-    #binding.pry
-    #sleep(0.01) until page.evaluate_script("App.cable.connection.getState() == 'open'")
-    sleep(3)
-    expect(page).to have_content content
-  end
-end

--- a/features/step_definitions/multi_window_steps.rb
+++ b/features/step_definitions/multi_window_steps.rb
@@ -5,6 +5,7 @@ end
 
 Given(/^I switch to window "([^"]*)"$/) do |index|
   switch_to_window(windows[index.to_i - 1])
+  sleep(2)
 end
 
 Then(/^I should have "([^"]*)" active windows$/) do |count|
@@ -19,9 +20,5 @@ Given(/^I am on the quiz page for "([^"]*)" in window "([^"]*)"$/) do |quiz, ind
 end
 
 Then(/^I should see "([^"]*)" within window "([^"]*)"$/) do |content, index|
-  # switch_to_window(windows[index.to_i - 1])
-  # steps %{
-  #   Then show me the page
-  # }
   expect(page).to have_content content
 end

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -6,7 +6,6 @@ Given(/^I am on the quiz "([^"]*)" page$/) do |page|
 end
 
 And(/^I enter the code for "([^"]*)"$/) do |quiz|
-  puts windows.last
   quiz = Quiz.find_by(name: quiz)
   fill_in :code, with: quiz.code
   click_link_or_button 'Submit'

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -6,6 +6,7 @@ Given(/^I am on the quiz "([^"]*)" page$/) do |page|
 end
 
 And(/^I enter the code for "([^"]*)"$/) do |quiz|
+  puts windows.last
   quiz = Quiz.find_by(name: quiz)
   fill_in :code, with: quiz.code
   click_link_or_button 'Submit'

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -38,3 +38,8 @@ Given /^there is a "([^\"]+)" cookie set to "([^\"]+)"$/ do |key, value|
     raise "no cookie-setter implemented for driver #{Capybara.current_session.driver.class.name}"
   end
 end
+
+
+And(/^I broadcast to the Qiz channel$/) do
+  ActionCable.server.broadcast 'quiz_channel', 'The Quiz begins!'
+end

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -16,6 +16,11 @@ Then(/^I should be on the quiz page for "([^"]*)"$/) do |quiz|
   expect(current_path).to eq quiz_path(quiz)
 end
 
+Then(/^I am on the quiz page for "([^"]*)"$/) do |quiz|
+  quiz = Quiz.find_by(name: quiz)
+  visit quiz_path(quiz)
+end
+
 And(/^I should see a Create Team form$/) do
   expect(page).to have_css('form#create_team')
 end

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -38,8 +38,3 @@ Given /^there is a "([^\"]+)" cookie set to "([^\"]+)"$/ do |key, value|
     raise "no cookie-setter implemented for driver #{Capybara.current_session.driver.class.name}"
   end
 end
-
-
-And(/^I broadcast to the Qiz channel$/) do
-  ActionCable.server.broadcast 'quiz_channel', 'The Quiz begins!'
-end

--- a/features/step_definitions/quiz_steps.rb
+++ b/features/step_definitions/quiz_steps.rb
@@ -11,19 +11,13 @@ Then(/^I should see a quiz code$/) do
   expect(page).to have_content @quiz.code
 end
 
-
-Given(/^I open a new window$/) do
-  open_new_window
+Given(/^I switch to a new window$/) do
+  window = open_new_window
+  switch_to_window(window)
 end
 
-
-And(/^I am on the quiz page for "([^"]*)" within window "([^"]*)"$/) do |quiz_name, window|
-  index = window.to_i - 1
-  quiz = Quiz.find_by(name: quiz_name)
-  within_window(switch_to_window(windows[index])) do
-    visit quizmaster_quiz_path(quiz)
-    save_screenshot("#{index}.png")
-  end
+Given(/^I switch to window "([^"]*)"$/) do |index|
+  switch_to_window(windows[index.to_i - 1])
 end
 
 Then(/^I should have "([^"]*)" active windows$/) do |count|

--- a/features/step_definitions/quiz_steps.rb
+++ b/features/step_definitions/quiz_steps.rb
@@ -14,24 +14,18 @@ end
 
 Given(/^I open a new window$/) do
   open_new_window
-  @window_1 = windows.first
-  @window_2 = windows.last
 end
 
+
+And(/^I am on the quiz page for "([^"]*)" within window "([^"]*)"$/) do |quiz_name, window|
+  index = window.to_i - 1
+  quiz = Quiz.find_by(name: quiz_name)
+  within_window(switch_to_window(windows[index])) do
+    visit quizmaster_quiz_path(quiz)
+    save_screenshot("#{index}.png")
+  end
+end
 
 Then(/^I should have "([^"]*)" active windows$/) do |count|
-  puts @window_1.session.body
-  puts @window_2.session.body
   expect(windows.count).to eq count.to_i
-end
-
-And(/^I am on the quiz page for "([^"]*)" within window "([^"]*)"$/) do |name, window|
-  index = window.to_i - 1
-  within_window windows[index] do
-    visit '/quiz'
-    # steps %Q{
-    #     Given I am on the quiz page for "#{name}"
-    #       }
-  end
-  puts windows[index].session.body
 end

--- a/features/step_definitions/quiz_steps.rb
+++ b/features/step_definitions/quiz_steps.rb
@@ -10,3 +10,28 @@ end
 Then(/^I should see a quiz code$/) do
   expect(page).to have_content @quiz.code
 end
+
+
+Given(/^I open a new window$/) do
+  open_new_window
+  @window_1 = windows.first
+  @window_2 = windows.last
+end
+
+
+Then(/^I should have "([^"]*)" active windows$/) do |count|
+  puts @window_1.session.body
+  puts @window_2.session.body
+  expect(windows.count).to eq count.to_i
+end
+
+And(/^I am on the quiz page for "([^"]*)" within window "([^"]*)"$/) do |name, window|
+  index = window.to_i - 1
+  within_window windows[index] do
+    visit '/quiz'
+    # steps %Q{
+    #     Given I am on the quiz page for "#{name}"
+    #       }
+  end
+  puts windows[index].session.body
+end

--- a/features/step_definitions/quiz_steps.rb
+++ b/features/step_definitions/quiz_steps.rb
@@ -2,24 +2,11 @@ Given(/^there is a quiz called "([^"]*)"$/) do |name|
   FactoryGirl.create(:quiz, name: name)
 end
 
-Given(/^I am on the quiz page for "([^"]*)"$/) do |quiz_name|
+Given(/^I am on the quizmaster page for "([^"]*)"$/) do |quiz_name|
   @quiz = Quiz.find_by(name: quiz_name)
   visit quizmaster_quiz_path(@quiz)
 end
 
 Then(/^I should see a quiz code$/) do
   expect(page).to have_content @quiz.code
-end
-
-Given(/^I switch to a new window$/) do
-  window = open_new_window
-  switch_to_window(window)
-end
-
-Given(/^I switch to window "([^"]*)"$/) do |index|
-  switch_to_window(windows[index.to_i - 1])
-end
-
-Then(/^I should have "([^"]*)" active windows$/) do |count|
-  expect(windows.count).to eq count.to_i
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,7 +13,7 @@ end
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, js_errors: false, timeout: 30)
+  Capybara::Poltergeist::Driver.new(app, js_errors: true, timeout: 30)
 end
 
 Capybara.javascript_driver = :poltergeist

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -18,3 +18,11 @@ end
 
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 10
+
+
+Capybara.register_server :puma do |app, port, host|
+  require 'puma'
+  Puma::Server.new(app).tap do |s|
+    s.add_tcp_listener host, port
+  end.run.join
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,12 +13,11 @@ end
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, js_errors: true, timeout: 30)
+  Capybara::Poltergeist::Driver.new(app, js_errors: false, timeout: 30)
 end
 
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 10
-
 
 Capybara.register_server :puma do |app, port, host|
   require 'puma'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,3 +26,5 @@ Capybara.register_server :puma do |app, port, host|
     s.add_tcp_listener host, port
   end.run.join
 end
+
+Capybara.server = :puma

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,4 @@
+
+Before '@action_cable' do
+  system( "redis-server /usr/local/etc/redis.conf")
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,6 +1,5 @@
 
 Before '@action_cable' do
-  Capybara.server = :puma
   RedisTest.start
   RedisTest.configure(:default)
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,4 +1,18 @@
 
 Before '@action_cable' do
-  system( "redis-server /usr/local/etc/redis.conf")
+  # raise "unable to launch redis-server" unless system( "redis-server /usr/local/etc/redis.conf")
+  # dir_temp = File.expand_path(File.join(Rails.root, 'tmp'))
+  # dir_conf = File.expand_path(File.join(Rails.root, 'config'))
+  # cwd = Dir.getwd
+  # Dir.chdir(Rails.root)
+  # raise "unable to launch redis-server" unless system("redis-server #{dir_conf}/redis-#{env}.conf")
+  # raise "unable to launch redis-server" unless Redis.new(host: 'localhost', port: 6379, db: 0)
+# end
+  RedisTest.start
+  RedisTest.configure(:default)
+end
+
+After '@action_cable' do
+  RedisTest.clear
+  RedisTest.stop
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,9 +1,8 @@
-
 Before '@action_cable' do
   RedisTest.start
   RedisTest.configure(:default)
 end
-#
+
 After '@action_cable' do
   RedisTest.clear
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,18 +1,14 @@
 
 Before '@action_cable' do
-  # raise "unable to launch redis-server" unless system( "redis-server /usr/local/etc/redis.conf")
-  # dir_temp = File.expand_path(File.join(Rails.root, 'tmp'))
-  # dir_conf = File.expand_path(File.join(Rails.root, 'config'))
-  # cwd = Dir.getwd
-  # Dir.chdir(Rails.root)
-  # raise "unable to launch redis-server" unless system("redis-server #{dir_conf}/redis-#{env}.conf")
-  # raise "unable to launch redis-server" unless Redis.new(host: 'localhost', port: 6379, db: 0)
-# end
+  Capybara.server = :puma
   RedisTest.start
   RedisTest.configure(:default)
 end
-
+#
 After '@action_cable' do
   RedisTest.clear
+end
+
+at_exit do
   RedisTest.stop
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.strategy = :translation
     DatabaseCleaner.clean_with(:truncation)
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :translation
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
   end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/132561053

Changes proposed in this pull request:
- Add a personalized message box and 'Start the Quiz' button to Quizmaster's Quiz page
- Use JQuery to hide message box and show 'you started the quiz'
- Display Quizmaster's message on Team pages

What I have learned working on this feature:
- How to use `onclick` events on Rails forms
- ActionCable is a huge bastard.

Screenshot:
![screen shot 2016-10-19 at 10 11 05 pm](https://cloud.githubusercontent.com/assets/20141428/19535688/0f983eac-9649-11e6-957f-042836a8032a.png)

Summary of where we're at and what we tried:
- Using redis as a server.
- The test environment doesn't receive the cable, but if you turn on the redis server, the test message will show up on localhost.
- The test browser doesn't seem to subscribe to the channel

Ready for review!