### PR TITLE
Teams can submit Answers

### DIFF
--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -24,7 +24,9 @@ App.cable.subscriptions.create("QuizChannel", {
         );
       } else {
         return this.collection().html(
-          "<p>" + data.index + ". " + data.question + "</p>"
+          data
+          // "<p>" + data.index + ". " + data.question + "</p>"
+
         );
       }
     }

--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -1,4 +1,4 @@
-App.cable.subscriptions.create("QuizChannel", {
+App.quiz = App.cable.subscriptions.create("QuizChannel", {
     collection: function () {
         return $("#message");
     },
@@ -25,5 +25,25 @@ App.cable.subscriptions.create("QuizChannel", {
         } else {
             return this.collection().html(data);
         }
+    },
+    submitAnswer: function (message) {
+        return this.perform('submit_answer', {
+            message: message
+        });
     }
 });
+
+$('#answer').submit(function (e) {
+    var $this, textarea;
+    $this = $(this);
+    textarea = $this.find('#body');
+    if ($.trim(textarea.val()).length > 1) {
+        App.quiz.submitAnswer({message: textarea.val(), answer_id: 2});
+        textarea.val('');
+    }
+    e.preventDefault();
+    return false;
+});
+
+
+

--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -33,17 +33,6 @@ App.quiz = App.cable.subscriptions.create("QuizChannel", {
     }
 });
 
-$('#answer').submit(function (e) {
-    var $this, textarea;
-    $this = $(this);
-    textarea = $this.find('#body');
-    if ($.trim(textarea.val()).length > 1) {
-        App.quiz.submitAnswer({message: textarea.val(), answer_id: 2});
-        textarea.val('');
-    }
-    e.preventDefault();
-    return false;
-});
 
 
 

--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -17,17 +17,13 @@ App.cable.subscriptions.create("QuizChannel", {
 
     },
 
-    printMessage: function(data) {
-      if(data.welcome == "true") {
-        return this.collection().html(
-          "<p>" + data.message + "</p>"
-        );
-      } else {
-        return this.collection().html(
-          data
-          // "<p>" + data.index + ". " + data.question + "</p>"
-
-        );
-      }
+    printMessage: function (data) {
+        if (data.welcome == "true") {
+            return this.collection().html(
+                "<p>" + data.message + "</p>"
+            );
+        } else {
+            return this.collection().html(data);
+        }
     }
 });

--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -23,6 +23,7 @@ App.cable.subscriptions.create("QuizChannel", {
           "<p>" + data.message + "</p>"
         );
       } else {
+          console.log(data);
         return this.collection().html(
           data
           // "<p>" + data.index + ". " + data.question + "</p>"

--- a/app/assets/javascripts/channels/quiz.js
+++ b/app/assets/javascripts/channels/quiz.js
@@ -23,7 +23,6 @@ App.cable.subscriptions.create("QuizChannel", {
           "<p>" + data.message + "</p>"
         );
       } else {
-          console.log(data);
         return this.collection().html(
           data
           // "<p>" + data.index + ". " + data.question + "</p>"

--- a/app/channels/quiz_channel.rb
+++ b/app/channels/quiz_channel.rb
@@ -12,7 +12,9 @@ class QuizChannel < ApplicationCable::Channel
     params = data['message'].symbolize_keys!
     question = Question.find(params[:question_id])
     team = Team.find(params[:team_id])
-    Answer.create(body: params[:answer], question: question, team: team)
+    Answer.create(body: params[:answer],
+                  question: question,
+                  team: team)
     BroadcastMessageJob.perform_now({message: 'Answer submitted!', welcome: 'true'})
   end
 end

--- a/app/channels/quiz_channel.rb
+++ b/app/channels/quiz_channel.rb
@@ -7,4 +7,12 @@ class QuizChannel < ApplicationCable::Channel
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
   end
+
+  def submit_answer(data)
+    params = data['message'].symbolize_keys!
+    question = Question.find(params[:question_id])
+    team = Team.find(params[:team_id])
+    Answer.create(body: params[:answer], question: question, team: team)
+    BroadcastMessageJob.perform_now({message: 'Answer submitted!', welcome: 'true'})
+  end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -6,7 +6,7 @@ class GamesController < ApplicationController
 
   def show
     @team = Team.find(cookies['team_id']) unless cookies['team_id'].nil?
-    render :show, locals:{message: "Welcome to quiz: #{@quiz.name}"}
+    render :show, locals: {message: "Welcome to quiz: #{@quiz.name}"}
   end
 
   def access_quiz
@@ -25,7 +25,8 @@ class GamesController < ApplicationController
     question = Question.find(params[:question_id])
     team = Team.find(params[:team_id])
     @answer = Answer.create(body: params[:body], question: question, team: team)
-    render nothing: true
+    BroadcastMessageJob.perform_now({message: 'Answer submitted!', welcome: 'true'})
+    head :ok
   end
 
   private

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -21,6 +21,13 @@ class GamesController < ApplicationController
     redirect_to quiz_path(quiz)
   end
 
+  def send_answer
+    question = Question.find(params[:question_id])
+    team = Team.find(params[:team_id])
+    @answer = Answer.create(body: params[:body], question: question, team: team)
+    render nothing: true
+  end
+
   private
   def get_quiz
     @quiz = Quiz.find(params[:id])

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -21,14 +21,6 @@ class GamesController < ApplicationController
     redirect_to quiz_path(quiz)
   end
 
-  def send_answer
-    question = Question.find(params[:question_id])
-    team = Team.find(params[:team_id])
-    @answer = Answer.create(body: params[:body], question: question, team: team)
-    BroadcastMessageJob.perform_now({message: 'Answer submitted!', welcome: 'true'})
-    head :ok
-  end
-
   private
   def get_quiz
     @quiz = Quiz.find(params[:id])

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -14,7 +14,7 @@ class Quizmaster::QuizzesController < ApplicationController
 
   def send_question
     question = Question.find(params[:question_id])
-    content = {question: question.body, index: params[:index]}
+    content = {question: question.body, index: params[:index], quiz_id: params[:id], question_id: params[:question_id], team_id: cookies['team_id']}
     broadcast_content(content)
   end
 

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -7,8 +7,8 @@ class Quizmaster::QuizzesController < ApplicationController
 
   def start_quiz
     @questions = @quiz.questions
-    content = {message: params[:message], welcome: params[:welcome]}
-    broadcast_content(content)
+    content = {message: params[:message], welcome: params[:welcome], quiz_id: params[:id]}
+    BroadcastMessageJob.perform_now(content)
     render :show
   end
 

--- a/app/jobs/broadcast_message_job.rb
+++ b/app/jobs/broadcast_message_job.rb
@@ -1,0 +1,7 @@
+class BroadcastMessageJob < ApplicationJob
+  queue_as :default
+
+  def perform(data)
+    ActionCable.server.broadcast 'quiz_channel', data
+  end
+end

--- a/app/jobs/broadcast_quiz_job.rb
+++ b/app/jobs/broadcast_quiz_job.rb
@@ -6,8 +6,6 @@ class BroadcastQuizJob < ApplicationJob
   end
 
   def create_partial(data)
-    # @answer = Answer.new(quiz_id: data.quiz_id, question_id: data.question_id)
-    @quiz = Quiz.find(data[:quiz_id])
     ApplicationController.renderer.render(partial: './partials/question', locals: {data: data})
   end
 end

--- a/app/jobs/broadcast_quiz_job.rb
+++ b/app/jobs/broadcast_quiz_job.rb
@@ -11,3 +11,4 @@ class BroadcastQuizJob < ApplicationJob
     ApplicationController.renderer.render(partial: './partials/question', locals: {data: data})
   end
 end
+

--- a/app/jobs/broadcast_quiz_job.rb
+++ b/app/jobs/broadcast_quiz_job.rb
@@ -7,6 +7,7 @@ class BroadcastQuizJob < ApplicationJob
 
   def create_partial(data)
     # @answer = Answer.new(quiz_id: data.quiz_id, question_id: data.question_id)
+    @quiz = Quiz.find(data[:quiz_id])
     ApplicationController.renderer.render(partial: './partials/question', locals: {data: data})
   end
 end

--- a/app/jobs/broadcast_quiz_job.rb
+++ b/app/jobs/broadcast_quiz_job.rb
@@ -6,6 +6,7 @@ class BroadcastQuizJob < ApplicationJob
   end
 
   def create_partial(data)
+    # @answer = Answer.new(quiz_id: data.quiz_id, question_id: data.question_id)
     ApplicationController.renderer.render(partial: './partials/question', locals: {data: data})
   end
 end

--- a/app/jobs/broadcast_quiz_job.rb
+++ b/app/jobs/broadcast_quiz_job.rb
@@ -1,7 +1,11 @@
 class BroadcastQuizJob < ApplicationJob
   queue_as :default
 
-  def perform(message)
-    ActionCable.server.broadcast 'quiz_channel', message
+  def perform(data)
+    ActionCable.server.broadcast 'quiz_channel', create_partial(data)
+  end
+
+  def create_partial(data)
+    ApplicationController.renderer.render(partial: './partials/question', locals: {data: data})
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,5 @@
+class Answer < ApplicationRecord
+  belongs_to :question
+  belongs_to :team
+  validates_presence_of :body, :question, :team
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,5 @@
 class Question < ApplicationRecord
   validates_presence_of :body, :answer, :quiz_id
   belongs_to :quiz
+  has_many :answers
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,4 +2,5 @@ class Team < ApplicationRecord
   validates_presence_of :name, :quiz_id
 
   belongs_to :quiz
+  has_many :answers
 end

--- a/app/views/games/index.html.haml
+++ b/app/views/games/index.html.haml
@@ -1,5 +1,5 @@
 .box
   %h1 Play the game
   = form_tag access_quiz_path, method: :post do
-    = text_field_tag :code, 'Enter your code', class: 'form-control code'
+    = text_field_tag :code, nil, placeholder: 'Enter your code', class: 'form-control code'
     = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block'

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -3,7 +3,7 @@
   - if cookies['team_id'].nil?
     %p Enter your teamname and press the button!
     = form_tag quiz_create_team_path(@quiz), id: 'create_team', remote: true do
-      = text_field_tag 'team[name]', 'Team Name', class: 'form-control code'
+      = text_field_tag 'team[name]', nil, placeholder: 'Team Name', class: 'form-control code'
       = submit_tag 'Create Team', class: 'btn btn-primary btn-lg btn-block'
   - else
     %p Get ready for the quiz, #{@team.name}!

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,6 +1,6 @@
 .answer_form
   = data[:question]
-  = form_tag quiz_send_answer_path(data[:quiz_id]), id: 'answer', remote: true do
+  = form_tag quiz_send_answer_path(quiz_id: data[:quiz_id]), id: 'answer', remote: true do
     = hidden_field_tag 'question_id', data[:question_id]
     = hidden_field_tag 'team_id', data[:team_id]
     = text_field_tag 'body', '', class: 'form-control code'

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -11,7 +11,7 @@
 :javascript
   $(document).ready(function () {
     $('.wait').hide();
-    this.submitAnswer = function (e) {
+    this.submitAnswer = function () {
       var $this, quiz, answer, question, team ;
       $this = $(this);
       $('.answer_form').hide();
@@ -24,7 +24,7 @@
         App.quiz.submitAnswer({answer: answer.val(), team_id: team.val(), quiz_id: quiz.val(), question_id: question.val()});
         answer.val('');
       }
-      e.preventDefault();
+      //e.preventDefault();
       return false;
     };
   });

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,18 +1,32 @@
 .answer_form
   = data[:question]
-  = form_tag quiz_send_answer_path(quiz_id: data[:quiz_id]), id: 'answer', remote: true do
-    = hidden_field_tag 'question_id', data[:question_id]
-    = hidden_field_tag 'team_id', data[:team_id]
-    = text_field_tag 'body', '', class: 'form-control code'
-    = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block', onclick: 'submitAnswer();'
+  =# form_tag quiz_send_answer_path(quiz_id: data[:quiz_id]), id: 'answer', remote: true do
+  =# form_tag '#', id: 'answer', remote: true do
+  = hidden_field_tag 'quiz_id', data[:quiz_id]
+  = hidden_field_tag 'question_id', data[:question_id]
+  = hidden_field_tag 'team_id', data[:team_id]
+  = text_field_tag 'body', '', class: 'form-control code'
+  = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block', onclick: 'submitAnswer();'
 .wait
   The next question is coming soon!
 
 :javascript
-  $(document).ready( function() {
+  $(document).ready(function () {
     $('.wait').hide();
-    this.submitAnswer = function() {
+    this.submitAnswer = function (e) {
+      var $this, quiz, answer, question, team ;
+      $this = $(this);
       $('.answer_form').hide();
       $('.wait').show();
+      quiz = $this.find('#quiz_id');
+      team = $this.find('#team_id');
+      answer = $this.find('#body');
+      question = $this.find('#question_id');
+      if ($.trim(answer.val()).length > 1) {
+        App.quiz.submitAnswer({answer: answer.val(), team_id: team.val(), quiz_id: quiz.val(), question_id: question.val()});
+        answer.val('');
+      }
+      e.preventDefault();
+      return false;
     };
   });

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,6 +1,7 @@
-Here's the partial mothafuckas!
+= data[:question]
 = form_tag quiz_send_answer_path(data[:quiz_id]), id: 'answer', remote: true do
   = hidden_field_tag 'question_id', data[:question_id]
   = hidden_field_tag 'team_id', data[:team_id]
   = text_field_tag 'body', '', class: 'form-control code'
   = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block'
+/ We'll need a function attached to this button to hide the form and say 'You submitted an answer'

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,0 +1,1 @@
+Here's the partial mothafuckas!

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,1 +1,4 @@
 Here's the partial mothafuckas!
+= form_tag answer_create_path, id: 'answer', remote: true do
+  = text_field_tag 'answer', '', class: 'form-control code'
+  = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block'

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,4 +1,6 @@
 Here's the partial mothafuckas!
-= form_tag answer_create_path, id: 'answer', remote: true do
-  = text_field_tag 'answer', '', class: 'form-control code'
+= form_tag quiz_send_answer_path(data[:quiz_id]), id: 'answer', remote: true do
+  = hidden_field_tag 'question_id', data[:question_id]
+  = hidden_field_tag 'team_id', data[:team_id]
+  = text_field_tag 'body', '', class: 'form-control code'
   = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block'

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,8 +1,6 @@
 .answer_form
   = data[:question]
-  = hidden_field_tag 'quiz_id', data[:quiz_id]
-  = hidden_field_tag 'question_id', data[:question_id]
-  = hidden_field_tag 'team_id', data[:team_id]
+  #info{data: {quiz_id: data[:quiz_id], question_id: data[:question_id], team_id: data[:team_id]}}
   = text_field_tag 'body', '', class: 'form-control code'
   = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block', onclick: 'submitAnswer();'
 .wait
@@ -12,19 +10,20 @@
   $(document).ready(function () {
     $('.wait').hide();
     this.submitAnswer = function () {
-      var $this, quiz, answer, question, team ;
+      var $this, dataset, quiz, answer, question, team ;
       $this = $(this);
-      $('.answer_form').hide();
-      $('.wait').show();
-      quiz = $this.find('#quiz_id');
-      team = $this.find('#team_id');
+      dataset = $this.find('#info')
+      quiz = dataset.data().quizId;
+      team = dataset.data().teamId;
+      question = dataset.data().questionId;
       answer = $this.find('#body');
-      question = $this.find('#question_id');
-      if ($.trim(answer.val()).length > 1) {
-        App.quiz.submitAnswer({answer: answer.val(), team_id: team.val(), quiz_id: quiz.val(), question_id: question.val()});
-        answer.val('');
+      if ($.trim(answer.val()).length >= 1) {
+        App.quiz.submitAnswer({answer: answer.val(), team_id: team, quiz_id: quiz, question_id: question});
+        $('.answer_form').hide();
+        $('.wait').show();
+      } else {
+        $('#message').append('WTF Dude?!?')
       }
-      //e.preventDefault();
       return false;
     };
   });

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,7 +1,5 @@
 .answer_form
   = data[:question]
-  =# form_tag quiz_send_answer_path(quiz_id: data[:quiz_id]), id: 'answer', remote: true do
-  =# form_tag '#', id: 'answer', remote: true do
   = hidden_field_tag 'quiz_id', data[:quiz_id]
   = hidden_field_tag 'question_id', data[:question_id]
   = hidden_field_tag 'team_id', data[:team_id]

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,7 +1,18 @@
-= data[:question]
-= form_tag quiz_send_answer_path(data[:quiz_id]), id: 'answer', remote: true do
-  = hidden_field_tag 'question_id', data[:question_id]
-  = hidden_field_tag 'team_id', data[:team_id]
-  = text_field_tag 'body', '', class: 'form-control code'
-  = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block'
-/ We'll need a function attached to this button to hide the form and say 'You submitted an answer'
+.answer_form
+  = data[:question]
+  = form_tag quiz_send_answer_path(data[:quiz_id]), id: 'answer', remote: true do
+    = hidden_field_tag 'question_id', data[:question_id]
+    = hidden_field_tag 'team_id', data[:team_id]
+    = text_field_tag 'body', '', class: 'form-control code'
+    = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block', onclick: 'submitAnswer();'
+.wait
+  The next question is coming soon!
+
+:javascript
+  $(document).ready( function() {
+    $('.wait').hide();
+    this.submitAnswer = function() {
+      $('.answer_form').hide();
+      $('.wait').show();
+    };
+  });

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -2,10 +2,9 @@
   %h1= @quiz.name
   %h3= @quiz.code
   .activate_quiz
-    = form_tag '#', id: 'start_quiz', controller: :quizzes, action: :start_quiz, method: :post, remote: true do
-      = hidden_field_tag 'id', @quiz.id
+    = form_tag quizmaster_path(@quiz), id: 'start_quiz', remote: true do
       = hidden_field_tag 'welcome', true
-      = text_field_tag 'message', 'Welcome message', class: 'form-control code'
+      = text_field_tag 'message', nil, placeholder: 'Welcome message', class: 'form-control code'
       = submit_tag 'Start the Quiz', id: 'start_button', class: 'btn btn-primary btn-lg btn-block', onclick: 'showSuccess();'
   .quiz_started
     %p You have started the quiz!
@@ -14,13 +13,13 @@
     - @questions.each_with_index do |question, index|
       .question{id: "question#{index}"}
         %p= question.body
-        = form_tag '/quizmaster/send_question', id: 'send_question', controller: :quizzes, action: :send_question, remote: true do
+        = form_tag url: {controller: :quizzes, action: :send_question}, id: 'send_question', remote: true do
           = hidden_field_tag 'id', @quiz.id
           = hidden_field_tag 'welcome', false
           = hidden_field_tag 'index', (index.to_i + 1)
           = hidden_field_tag 'question_id', question.id
           .btn-group
-          = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success'
+            = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success'
 
 
 

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -13,7 +13,7 @@
     - @questions.each_with_index do |question, index|
       .question{id: "question#{index}"}
         %p= question.body
-        = form_tag url: {controller: :quizzes, action: :send_question}, id: 'send_question', remote: true do
+        = form_tag quizmaster_send_question_path, id: 'send_question', remote: true do
           = hidden_field_tag 'id', @quiz.id
           = hidden_field_tag 'welcome', false
           = hidden_field_tag 'index', (index.to_i + 1)

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -17,7 +17,7 @@
         = form_tag '/quizmaster/send_question', id: 'send_question', controller: :quizzes, action: :send_question, remote: true do
           = hidden_field_tag 'id', @quiz.id
           = hidden_field_tag 'welcome', false
-          = hidden_field_tag 'index', (index.to_i + 1) 
+          = hidden_field_tag 'index', (index.to_i + 1)
           = hidden_field_tag 'question_id', question.id
           .btn-group
           = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   resources :quiz, controller: :games, only: [:index, :show] do
     post '/create_team', controller: :games, action: :create_team
+    post '/send_answer', controller: :games, action: :send_answer
   end
 
   post 'access_quiz' , controller: :games, action: :access_quiz, as: :access_quiz

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ Rails.application.routes.draw do
 
   resources :quiz, controller: :games, only: [:index, :show] do
     post '/create_team', controller: :games, action: :create_team
-    post '/send_answer', controller: :games, action: :send_answer
   end
 
   post 'access_quiz' , controller: :games, action: :access_quiz, as: :access_quiz

--- a/db/migrate/20161020141421_create_answers.rb
+++ b/db/migrate/20161020141421_create_answers.rb
@@ -1,0 +1,12 @@
+class CreateAnswers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :answers do |t|
+      t.string :body
+      t.boolean :is_correct
+      t.references :question, foreign_key: true
+      t.references :team, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161019143759) do
+ActiveRecord::Schema.define(version: 20161020141421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "answers", force: :cascade do |t|
+    t.string   "body"
+    t.boolean  "is_correct"
+    t.integer  "question_id"
+    t.integer  "team_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.index ["question_id"], name: "index_answers_on_question_id", using: :btree
+    t.index ["team_id"], name: "index_answers_on_team_id", using: :btree
+  end
 
   create_table "questions", force: :cascade do |t|
     t.string   "body"
@@ -39,6 +50,8 @@ ActiveRecord::Schema.define(version: 20161019143759) do
     t.index ["quiz_id"], name: "index_teams_on_quiz_id", using: :btree
   end
 
+  add_foreign_key "answers", "questions"
+  add_foreign_key "answers", "teams"
   add_foreign_key "questions", "quizzes"
   add_foreign_key "teams", "quizzes"
 end

--- a/features/player/submit_answers.feature
+++ b/features/player/submit_answers.feature
@@ -13,6 +13,7 @@ Background:
 
 Scenario: I submit my answer
   Given I receive the first question
-  When I fill in "answer" with "Four"
-  And click the "Submit" button
+  When I fill in "body" with "Four"
+  And I click the "Submit" button
+  Then there should be "1" answer for the "Craft Academy" team
   Then I should see "Answer submitted!"

--- a/features/player/submit_answers.feature
+++ b/features/player/submit_answers.feature
@@ -1,0 +1,18 @@
+@javascript @action_cable
+Feature: As a Team
+  in order to participate in the game
+  I need to be able to submit Answers.
+
+Background:
+  Given there is a quiz called "Trivia"
+  And the following questions exist in "Trivia":
+    | body            | answer       |
+    | What is 2+2?    | Four         |
+    | Who is awesome? | Thomas is ok |
+  And there is a team named "Craft Academy"
+
+Scenario: I submit my answer
+  Given I receive the first question
+  When I fill in "answer" with "Four"
+  And click the "Submit" button
+  Then I should see "Answer submitted!"

--- a/features/step_definitions/quiz_steps.rb
+++ b/features/step_definitions/quiz_steps.rb
@@ -10,3 +10,14 @@ end
 Then(/^I should see a quiz code$/) do
   expect(page).to have_content @quiz.code
 end
+
+Given(/^I receive the first question$/) do
+  steps %Q{
+    Given there is a "team_id" cookie set to "Craft Academy"
+    When I am on the quiz page for "Trivia"
+    And I switch to a new window
+    And I am on the quizmaster page for "Trivia"
+    When I press the "Send" button for question "1"
+    And I switch to window "1"
+  }
+end

--- a/features/step_definitions/quiz_steps.rb
+++ b/features/step_definitions/quiz_steps.rb
@@ -21,3 +21,8 @@ Given(/^I receive the first question$/) do
     And I switch to window "1"
   }
 end
+
+Then(/^there should be "([^"]*)" answer for the "([^"]*)" team$/) do |count, team_name|
+  team = Team.find_by(name: team_name)
+  expect(team.answers.count).to eq count
+end

--- a/features/step_definitions/quiz_steps.rb
+++ b/features/step_definitions/quiz_steps.rb
@@ -12,7 +12,7 @@ Then(/^I should see a quiz code$/) do
 end
 
 Given(/^I receive the first question$/) do
-  steps %Q{
+  steps %q{
     Given there is a "team_id" cookie set to "Craft Academy"
     When I am on the quiz page for "Trivia"
     And I switch to a new window
@@ -23,6 +23,8 @@ Given(/^I receive the first question$/) do
 end
 
 Then(/^there should be "([^"]*)" answer for the "([^"]*)" team$/) do |count, team_name|
+  sleep(2)
   team = Team.find_by(name: team_name)
-  expect(team.answers.count).to eq count
+  expect(team.answers.count).to eq count.to_i
+  sleep(2)
 end

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :answer do
+    body "MyString"
+    is_correct false
+  end
+end

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -2,5 +2,7 @@ FactoryGirl.define do
   factory :answer do
     body "MyString"
     is_correct false
+    team {association(:team)}
+    question {association(:question)}
   end
 end

--- a/spec/jobs/broadcast_message_job_spec.rb
+++ b/spec/jobs/broadcast_message_job_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe BroadcastMessageJob, type: :job do
+  it 'matches with enqueued job' do
+    ActiveJob::Base.queue_adapter = :test
+    expect {
+      BroadcastMessageJob.perform_later('test')
+    }.to have_enqueued_job.with('test')
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Answer, type: :model do
+  describe 'DB table' do
+    it { is_expected.to have_db_column :body }
+    it { is_expected.to belong_to :question }
+    it { is_expected.to belong_to :team }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :body }
+    it { is_expected.to validate_presence_of :question }
+    it { is_expected.to validate_presence_of :team }
+  end
+
+  describe 'Factory' do
+    it 'should have a valid Factory' do
+      expect(FactoryGirl.create(:answer)).to be_valid
+    end
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Question, type: :model do
     it { is_expected.to have_db_column :body }
     it { is_expected.to have_db_column :answer }
     it { is_expected.to belong_to :quiz }
+    it { is_expected.to have_many :answers }
   end
 
   describe 'Validations' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Team, type: :model do
   describe 'DB table' do
     it { is_expected.to have_db_column :name }
     it { is_expected.to belong_to :quiz }
+    it { is_expected.to have_many :answers }
   end
 
   describe 'Validations' do


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/132561603

Changes proposed in this pull request:
- Create Answer model
- Render partial when Quizmaster sends Questions
- Answer form creates a new answer associated with their Team and the Question
- Creates new broadcast job for sending messages and refactors messages to use it

What I have learned working on this feature:
- How to store variables in divs
- How to read variables from HTML into JQuery
- How to use a partial with ActionCable

Screenshots: 
![screen shot 2016-10-21 at 10 41 07 am](https://cloud.githubusercontent.com/assets/20141428/19592189/eb328648-977a-11e6-92d4-82843f6a5f02.png)
![screen shot 2016-10-21 at 10 42 07 am](https://cloud.githubusercontent.com/assets/20141428/19592222/097639e2-977b-11e6-8d89-42d896ed4b26.png)


Ready for review!