### PR TITLE
Fix ActionCable settings for production (Heroku)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -p $PORT -e $RAILS_ENV

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,4 +8,4 @@ test:
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: ENV['REDIS_URL']

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,4 +8,4 @@ test:
 
 production:
   adapter: redis
-  url: ENV['REDIS_URL']
+  url: <%= ENV['REDIS_URL']  %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,8 +36,9 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  config.action_cable.url = 'wss://quizmasterone.herokuapp.com/cable'
+  config.action_cable
+        .allowed_request_origins = ['https://quizmasterone.herokuapp.com']
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,8 +37,9 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   config.action_cable.url = 'wss://quizmasterone.herokuapp.com/cable'
-  config.action_cable
-        .allowed_request_origins = ['https://quizmasterone.herokuapp.com']
+  config.action_cable.allowed_request_origins = [
+    'https://quizmasterone.herokuapp.com', %r{(http|https):\/\/quizmasterone.*}
+  ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/132893867

Changes proposed in this pull request:

Fix WebSocket configurations for ActionCable in production
- set `action_cable.url` and `action_cable.allowed_request_origins` in `production.rb`
- Create a `Procfile` to start `Puma` on Heroku
- Update Redis url for production, now reads from environment variable


What I have learned working on this feature: 
- How to configure and deploy an ActionCable application to Heroku


@tochman @AmberWilkie @Blokkinen @thesuss Ready for review!
