### PR TITLE
Quizmaster views results and declares a winner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -93,3 +93,23 @@ body {
   float: right;
   display: none;
 }
+
+.links {
+  margin: 2%;
+  padding: 1%;
+  font-size: 110%;
+  color: #ffffff;
+  align-self: center;
+  text-align: center;
+}
+
+.score {
+  font-size: 130%;
+  font-weight: bold;
+  background-color: #ffc501;
+  color: #fff;
+  max-width: 30px;
+  display: block;
+  float: right;
+  padding: 1%;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -65,7 +65,7 @@ body {
 .question p {
   font-size: 20px;
   float:left;
-  height:50px;
+  min-height:50px;
   line-height: 50px;
   margin-right: 51px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -93,6 +93,9 @@ body {
   float: right;
   display: none;
 }
+#correct {
+  display: none;
+}
 
 .links {
   margin: 2%;

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -38,6 +38,10 @@ class Quizmaster::QuizzesController < ApplicationController
     head :ok
   end
 
+  def results
+    @quiz = Quiz.find(params[:id])
+  end
+
   private
 
   def get_quiz

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -19,8 +19,9 @@ class Quizmaster::QuizzesController < ApplicationController
   end
 
   def send_results
-    # what if two teams have the same score?
-    message = "#{get_scores.last[:team].name} won!"
+    winner = Team.find_by(name: get_scores.last[:team].name)
+    winner.update_attribute(:is_winner, true)
+    message = "#{winner.name} won!"
     content = {message: message, welcome: 'true', quiz_id: @quiz.id}
     BroadcastMessageJob.perform_now(content)
     head :ok

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -19,10 +19,7 @@ class Quizmaster::QuizzesController < ApplicationController
   end
 
   def send_results
-    winner = Team.find_by(name: @quiz.get_scores.last[:team].name)
-    winner.update_attribute(:is_winner, true)
-    message = "#{winner.name} won!"
-    content = {message: message, welcome: 'true', quiz_id: @quiz.id}
+    content = {message: get_winner_message, welcome: 'true', quiz_id: @quiz.id}
     BroadcastMessageJob.perform_now(content)
     head :ok
   end
@@ -54,6 +51,12 @@ class Quizmaster::QuizzesController < ApplicationController
 
   def get_quiz
     @quiz = Quiz.find(params[:id])
+  end
+
+  def get_winner_message
+    winner = Team.find_by(name: @quiz.get_scores.last[:team].name)
+    winner.update_attribute(:is_winner, true)
+    message = "#{winner.name} won!"
   end
 
 end

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -19,7 +19,7 @@ class Quizmaster::QuizzesController < ApplicationController
   end
 
   def send_results
-    winner = Team.find_by(name: get_scores.last[:team].name)
+    winner = Team.find_by(name: @quiz.get_scores.last[:team].name)
     winner.update_attribute(:is_winner, true)
     message = "#{winner.name} won!"
     content = {message: message, welcome: 'true', quiz_id: @quiz.id}
@@ -56,12 +56,4 @@ class Quizmaster::QuizzesController < ApplicationController
     @quiz = Quiz.find(params[:id])
   end
 
-  def get_scores
-    scores = []
-    @quiz.teams.each do |team|
-      points = team.answers.where(is_correct: true).count
-      scores << {team: team, score: points}
-    end
-    scores.sort_by! {|score, points| points}
-  end
 end

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -18,6 +18,14 @@ class Quizmaster::QuizzesController < ApplicationController
     broadcast_content(content)
   end
 
+  def send_results
+    quiz = Quiz.find(params[:id])
+    message = "#{quiz.teams.where(is_winner: true).first} won!"
+    content = {message: message, welcome: true, quiz_id: quiz.id}
+    BroadcastMessageJob.perform_now(content)
+    head :ok
+  end
+
   def correct_answers
     @question = Question.find(params[:id])
     render :answers

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -20,8 +20,14 @@ class Quizmaster::QuizzesController < ApplicationController
 
   def send_results
     quiz = Quiz.find(params[:id])
-    message = "#{quiz.teams.where(is_winner: true).first} won!"
-    content = {message: message, welcome: true, quiz_id: quiz.id}
+    scores = []
+    quiz.teams.each do |team|
+      points = team.answers.where(is_correct: true).count
+      scores << {team: team, score: points}
+    end
+    scores.sort_by! {|_key, value| value}
+    message = "#{scores.last[:team].name} won!"
+    content = {message: message, welcome: 'true', quiz_id: quiz.id}
     BroadcastMessageJob.perform_now(content)
     head :ok
   end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -5,6 +5,15 @@ class Quiz < ApplicationRecord
   has_many :questions
   has_many :teams
 
+  def get_scores
+    scores = []
+    self.teams.each do |team|
+      points = team.answers.where(is_correct: true).count
+      scores << {team: team, score: points}
+    end
+    scores.sort_by! {|score, points| points}
+  end
+
   private
 
   def generate_random_code

--- a/app/views/quizmaster/quizzes/answers.html.haml
+++ b/app/views/quizmaster/quizzes/answers.html.haml
@@ -17,8 +17,8 @@
       %br/
       %br/
       %hr/
-  %divr{class: 'btn-sq-sm btn-success'}
-    = link_to 'Back to Questions', quizmaster_quiz_path(@question.quiz)
+  %divr
+    = link_to 'Back to Questions', quizmaster_quiz_path(@question.quiz), class: 'btn-sq-sm btn-success links'
 
 :javascript
   $(document).ready(function () {

--- a/app/views/quizmaster/quizzes/results.html.haml
+++ b/app/views/quizmaster/quizzes/results.html.haml
@@ -7,3 +7,5 @@
       .score
         = team.answers.where(is_correct: true).count
         -# we should get this logic out of the view
+  .send_results_button
+    = link_to 'Send Results', quizmaster_send_results_path(@quiz), class: 'btn btn-sq-sm btn-success'

--- a/app/views/quizmaster/quizzes/results.html.haml
+++ b/app/views/quizmaster/quizzes/results.html.haml
@@ -1,0 +1,9 @@
+.big-box
+  %h1= @quiz.name
+
+  .results_div
+    - @quiz.teams.each do |team|
+      = team.name
+      .score
+        = team.answers.where(is_correct: true).count
+        -# we should get this logic out of the view

--- a/app/views/quizmaster/quizzes/results.html.haml
+++ b/app/views/quizmaster/quizzes/results.html.haml
@@ -4,7 +4,10 @@
   .results_div
     - @quiz.teams.each do |team|
       = team.name
-      .score
+      .score{class: 'score'}
         = team.answers.where(is_correct: true).count
-  .send_results_button
-    = link_to 'Send Results', quizmaster_send_results_path(@quiz), method: :post, class: 'btn btn-sq-sm btn-success', remote: true
+      %hr/
+  %divr
+    = link_to 'Send Results', quizmaster_send_results_path(@quiz), method: :post, remote: true, class: 'btn-sq-sm btn-success links', id: 'send_results', onclick:"javascript:$(this).text('Resend Results');"
+  %divr
+    = link_to 'Back to Questions', quizmaster_quiz_path(@quiz), class: 'btn-sq-sm btn-success links'

--- a/app/views/quizmaster/quizzes/results.html.haml
+++ b/app/views/quizmaster/quizzes/results.html.haml
@@ -6,6 +6,5 @@
       = team.name
       .score
         = team.answers.where(is_correct: true).count
-        -# we should get this logic out of the view
   .send_results_button
     = link_to 'Send Results', quizmaster_send_results_path(@quiz), method: :post, class: 'btn btn-sq-sm btn-success', remote: true

--- a/app/views/quizmaster/quizzes/results.html.haml
+++ b/app/views/quizmaster/quizzes/results.html.haml
@@ -8,4 +8,4 @@
         = team.answers.where(is_correct: true).count
         -# we should get this logic out of the view
   .send_results_button
-    = link_to 'Send Results', quizmaster_send_results_path(@quiz), class: 'btn btn-sq-sm btn-success'
+    = link_to 'Send Results', quizmaster_send_results_path(@quiz), method: :post, class: 'btn btn-sq-sm btn-success', remote: true

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -22,6 +22,9 @@
             = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success', onclick: "showAnswers(#{index});"
           .btn-group#correct{id: "answer#{index}"}
             = link_to 'Correct', quizmaster_correct_answers_path(question), id: 'correct_button', class: 'btn btn-sq-sm btn-success'
+  %hr/
+  .results_button
+    = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn btn-sq-sm btn-success'
 
 
 

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -5,38 +5,36 @@
     = form_tag quizmaster_path(@quiz), id: 'start_quiz', remote: true do
       = hidden_field_tag 'welcome', true
       = text_field_tag 'message', nil, placeholder: 'Welcome message', class: 'form-control code'
-      = submit_tag 'Start the Quiz', id: 'start_button', class: 'btn btn-primary btn-lg btn-block', onclick: 'showSuccess();'
+      = submit_tag 'Start the Quiz', id: 'start_button', class: 'btn btn-primary btn-lg btn-block'
   .quiz_started
     %p You have started the quiz!
 
   .questions
     - @questions.each_with_index do |question, index|
-      .question{id: "question#{index}"}
+      .question{id: "question#{question.id}"}
         %p= question.body
         = form_tag quizmaster_send_question_path, id: 'send_question', remote: true do
           = hidden_field_tag 'id', @quiz.id
           = hidden_field_tag 'welcome', false
           = hidden_field_tag 'index', (index.to_i + 1)
           = hidden_field_tag 'question_id', question.id
-          .btn-group#send{id: "answer#{index}"}
-            = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success', onclick: "showAnswers(#{index});"
-          .btn-group#correct{id: "answer#{index}"}
+          .btn-group#send
+            = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success'
+          .btn-group#correct{style: 'display: none;'}
             = link_to 'Correct', quizmaster_correct_answers_path(question), id: 'correct_button', class: 'btn btn-sq-sm btn-success'
 
   = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'
 
 
-
 :javascript
-  $(document).ready( function() {
+  $(document).ready(function () {
     $('.quiz_started').hide();
-    $('[id^=correct_answer]').hide();
-    this.showSuccess = function() {
+    $('#start_button').click( function(){
       $('.activate_quiz').hide();
       $('.quiz_started').show();
-    };
-    this.showAnswers = function(index) {
-      $('[id^=send_answer]')[index].style.display = "none";
-      $('[id^=correct_answer]')[index].style.display = "inline-block";
-    };
+    });
+    $('#send_button').click(function(){
+      $(this)[0].style.display = "none";
+      $(this).parent().parent().find('#correct')[0].style.display = "inline-block";
+    });
   });

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -22,9 +22,8 @@
             = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success', onclick: "showAnswers(#{index});"
           .btn-group#correct{id: "answer#{index}"}
             = link_to 'Correct', quizmaster_correct_answers_path(question), id: 'correct_button', class: 'btn btn-sq-sm btn-success'
-  %hr/
-  .results_button
-    = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn btn-sq-sm btn-success'
+
+  = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'
 
 
 

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -19,9 +19,9 @@
           = hidden_field_tag 'index', (index.to_i + 1)
           = hidden_field_tag 'question_id', question.id
           .btn-group#send
-            = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success'
+            = submit_tag 'Send', id: "send_button#{question.id}", class: 'btn btn-sq-sm btn-success'
           .btn-group#correct
-            = link_to 'Correct', quizmaster_correct_answers_path(question), id: 'correct_button', class: 'btn btn-sq-sm btn-success'
+            = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
 
   = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'
 
@@ -33,7 +33,7 @@
       $('.activate_quiz').hide();
       $('.quiz_started').show();
     });
-    $('#send_button').click(function(){
+    $('[id^=send_button]').click(function(){
       $(this)[0].style.display = "none";
       $(this).parent().parent().find('#correct')[0].style.display = "inline-block";
     });

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -20,7 +20,7 @@
           = hidden_field_tag 'question_id', question.id
           .btn-group#send
             = submit_tag 'Send', id: 'send_button', class: 'btn btn-sq-sm btn-success'
-          .btn-group#correct{style: 'display: none;'}
+          .btn-group#correct
             = link_to 'Correct', quizmaster_correct_answers_path(question), id: 'correct_button', class: 'btn btn-sq-sm btn-success'
 
   = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     post '/send_question', controller: :quizzes, action: :send_question
     get 'quiz/answers/:id', controller: :quizzes, action: :correct_answers, as: :correct_answers
     get 'quiz/answers/mark/:id', controller: :quizzes, action: :mark_answers, as: :mark_answers
+    get '/results/:id', controller: :quizzes, action: :results, as: :results
   end
 
   resources :quiz, controller: :games, only: [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     get 'quiz/answers/:id', controller: :quizzes, action: :correct_answers, as: :correct_answers
     get 'quiz/answers/mark/:id', controller: :quizzes, action: :mark_answers, as: :mark_answers
     get '/results/:id', controller: :quizzes, action: :results, as: :results
+    post '/results/:id', controller: :quizzes, action: :send_results, as: :send_results
   end
 
   resources :quiz, controller: :games, only: [:index, :show] do

--- a/db/migrate/20161022175950_add_is_winner_to_team.rb
+++ b/db/migrate/20161022175950_add_is_winner_to_team.rb
@@ -1,0 +1,5 @@
+class AddIsWinnerToTeam < ActiveRecord::Migration[5.0]
+  def change
+    add_column :teams, :is_winner, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161020141421) do
+ActiveRecord::Schema.define(version: 20161022175950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,8 +45,9 @@ ActiveRecord::Schema.define(version: 20161020141421) do
   create_table "teams", force: :cascade do |t|
     t.string   "name"
     t.integer  "quiz_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "is_winner",  default: false
     t.index ["quiz_id"], name: "index_teams_on_quiz_id", using: :btree
   end
 

--- a/features/quizmaster/running_quiz.feature
+++ b/features/quizmaster/running_quiz.feature
@@ -17,6 +17,6 @@ Scenario: I send the first question
   When I am on the quiz page for "Trivia"
   And I switch to a new window
   And I am on the quizmaster page for "Trivia"
-  When I press the "Send" button for question "1"
+  When I press the "Send" button for question "What is 2+2?"
   And I switch to window "1"
   Then I should see "What is 2+2?"

--- a/features/quizmaster/view_answers.feature
+++ b/features/quizmaster/view_answers.feature
@@ -15,7 +15,6 @@ Background:
 
 Scenario: I correct the answers for a question
   Given I press the "Send" button for question "What is 2+2?"
-  And show me the page
   And "Amber Rocks!" has answered question "What is 2+2?" with "4"
   And "Craft Academy" has answered question "What is 2+2?" with "Six"
   When I click the "Correct" button

--- a/features/quizmaster/view_answers.feature
+++ b/features/quizmaster/view_answers.feature
@@ -17,7 +17,7 @@ Scenario: I correct the answers for a question
   Given I press the "Send" button for question "What is 2+2?"
   And "Amber Rocks!" has answered question "What is 2+2?" with "4"
   And "Craft Academy" has answered question "What is 2+2?" with "Six"
-  When I press the correct button for question "What is 2+2?"
+  When I click the "Correct" button
   Then I should be on the correction page for "What is 2+2?"
   When I click "right" on "4"
   And I click "wrong" on "Six"

--- a/features/quizmaster/view_answers.feature
+++ b/features/quizmaster/view_answers.feature
@@ -25,6 +25,13 @@ Scenario: I correct the answers for a question
   And "Craft Academy" should have "0" correct answers
   And I should see "Undo?"
 
+Scenario: I see multiple Correct links
+  Given I press the "Send" button for question "What is 2+2?"
+  And I press the "Send" button for question "Who is awesome?"
+  And "Craft Academy" has answered question "Who is awesome?" with "Thomas"
+  When I press the correct button for question "Who is awesome?"
+  Then I should see "Thomas"
+
 Scenario: The back button takes me back to my Quiz
   Given I press the "Send" button for question "What is 2+2?"
   And I click the "Correct" button

--- a/features/quizmaster/view_answers.feature
+++ b/features/quizmaster/view_answers.feature
@@ -14,7 +14,8 @@ Background:
   And I am on the quizmaster page for "Trivia"
 
 Scenario: I correct the answers for a question
-  Given I press the "Send" button for question "1"
+  Given I press the "Send" button for question "What is 2+2?"
+  And show me the page
   And "Amber Rocks!" has answered question "What is 2+2?" with "4"
   And "Craft Academy" has answered question "What is 2+2?" with "Six"
   When I click the "Correct" button
@@ -26,7 +27,7 @@ Scenario: I correct the answers for a question
   And I should see "Undo?"
 
 Scenario: The back button takes me back to my Quiz
-  Given I press the "Send" button for question "1"
+  Given I press the "Send" button for question "What is 2+2?"
   And I click the "Correct" button
   When I click the "Back to Questions" button
   Then I should be on the quizmaster page for "Trivia"

--- a/features/quizmaster/view_answers.feature
+++ b/features/quizmaster/view_answers.feature
@@ -17,7 +17,7 @@ Scenario: I correct the answers for a question
   Given I press the "Send" button for question "What is 2+2?"
   And "Amber Rocks!" has answered question "What is 2+2?" with "4"
   And "Craft Academy" has answered question "What is 2+2?" with "Six"
-  When I click the "Correct" button
+  When I press the correct button for question "What is 2+2?"
   Then I should be on the correction page for "What is 2+2?"
   When I click "right" on "4"
   And I click "wrong" on "Six"

--- a/features/quizmaster/view_results_page.feature
+++ b/features/quizmaster/view_results_page.feature
@@ -1,3 +1,4 @@
+@action_cable @javascript
 Feature: As a Quizmaster
   in order to declare a winner
   I need to see a tally of Teams' correct Answers.

--- a/features/quizmaster/view_results_page.feature
+++ b/features/quizmaster/view_results_page.feature
@@ -1,0 +1,22 @@
+Feature: As a Quizmaster
+  in order to declare a winner
+  I need to see a tally of Teams' correct Answers.
+
+Background:
+  Given there is a quiz called "Trivia"
+  # And the following questions exist in "Trivia":
+  #   | body            | answer       |
+  #   | What is 2+2?    | Four         |
+  #   | Who is awesome? | Thomas is ok |
+  And there is a team named "Craft Academy" playing "Trivia"
+  And there is a team named "Amber Rocks!" playing "Trivia"
+  And "Craft Academy" has answered "10" questions right
+  And "Amber Rocks!" has answered "11" questions right
+
+Scenario: I view and send results
+  And I am on the quizmaster page for "Trivia"
+  When I click the "Results" button
+  Then I should see "10"
+  When "Amber Rocks!" is looking at the quiz page for "Trivia"
+  And I click the "Send Results" button
+  Then "Amber Rocks!" should see "Amber Rocks! won!"

--- a/features/quizmaster/view_results_page.feature
+++ b/features/quizmaster/view_results_page.feature
@@ -5,10 +5,6 @@ Feature: As a Quizmaster
 
 Background:
   Given there is a quiz called "Trivia"
-  # And the following questions exist in "Trivia":
-  #   | body            | answer       |
-  #   | What is 2+2?    | Four         |
-  #   | Who is awesome? | Thomas is ok |
   And there is a team named "Craft Academy" playing "Trivia"
   And there is a team named "Amber Rocks!" playing "Trivia"
   And "Craft Academy" has answered "10" questions right

--- a/features/step_definitions/answer_steps.rb
+++ b/features/step_definitions/answer_steps.rb
@@ -9,6 +9,4 @@ Given(/^"([^"]*)" has answered "([^"]*)" questions right$/) do |team_name, count
   count.to_i.times do
     FactoryGirl.create(:answer, team: team, is_correct: true)
   end
-  expect(team.answers.where(is_correct: true).count).to eq count.to_i
-  # I realize you don't have expectations in Given steps - if this is here it's because I forgot to take it out at the end of the feature.
 end

--- a/features/step_definitions/answer_steps.rb
+++ b/features/step_definitions/answer_steps.rb
@@ -3,3 +3,12 @@ Given(/^"([^"]*)" has answered question "([^"]*)" with "([^"]*)"$/) do |team_nam
   question = Question.find_by(body: question)
   answer = FactoryGirl.create(:answer, team: team, question: question, body: answer)
 end
+
+Given(/^"([^"]*)" has answered "([^"]*)" questions right$/) do |team_name, count|
+  team = Team.find_by(name: team_name)
+  count.to_i.times do
+    FactoryGirl.create(:answer, team: team, is_correct: true)
+  end
+  expect(team.answers.where(is_correct: true).count).to eq count.to_i
+  # I realize you don't have expectations in Given steps - if this is here it's because I forgot to take it out at the end of the feature.
+end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -19,12 +19,7 @@ Given(/^I am on the page for "([^"]*)"$/) do |name|
   visit quiz_path(quiz)
 end
 
-When(/^I press the "([^"]*)" button$/) do |button|
-  click_link_or_button button
-end
-
-
-When(/^I click the "([^"]*)" button$/) do |button|
+When(/^I (?:press|click) the "([^"]*)" (?:button|link)$/) do |button|
   click_link_or_button button
 end
 

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -26,7 +26,6 @@ And(/^I should see a Create Team form$/) do
 end
 
 Given /^there is a "([^\"]+)" cookie set to "([^\"]+)"$/ do |key, value|
-  binding.pry
   team_id = Team.find_by(name: value).id
   case Capybara.current_session.driver
   when Capybara::Poltergeist::Driver
@@ -54,8 +53,8 @@ And(/^there is a team named "([^"]*)" playing "([^"]*)"$/) do |team_name, quiz_n
 end
 
 When(/^"([^"]*)" is looking at the quiz page for "([^"]*)"$/) do |team_name, quiz_name|
-    steps %q{
-      Given there is a "team_id" cookie set to #{team_name}
+    steps %Q{
+      Given there is a "team_id" cookie set to "#{team_name}"
       And I switch to a new window
       And I am on the quiz page for "Trivia"
     }

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -26,6 +26,7 @@ And(/^I should see a Create Team form$/) do
 end
 
 Given /^there is a "([^\"]+)" cookie set to "([^\"]+)"$/ do |key, value|
+  binding.pry
   team_id = Team.find_by(name: value).id
   case Capybara.current_session.driver
   when Capybara::Poltergeist::Driver

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -55,7 +55,7 @@ end
 
 When(/^"([^"]*)" is looking at the quiz page for "([^"]*)"$/) do |team_name, quiz_name|
     steps %q{
-      Given there is a "team_id" cookie set to "#{team_name}"
+      Given there is a "team_id" cookie set to #{team_name}
       And I switch to a new window
       And I am on the quiz page for "Trivia"
     }

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -57,14 +57,13 @@ When(/^"([^"]*)" is looking at the quiz page for "([^"]*)"$/) do |team_name, qui
       Given there is a "team_id" cookie set to "#{team_name}"
       And I switch to a new window
       And I am on the quiz page for "Trivia"
+      And I switch to window "1"
     }
 end
 
 Then(/^"([^"]*)" should see "([^"]*)"$/) do |team_name, content|
   steps %q{
-    Given there is a "team_id" cookie set to "#{team_name}"
-    And I switch to a new window
-    And I am on the quiz page for "Trivia"
+    Given I switch to window "2"
   }
   expect(page).to have_content content
 end

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -51,3 +51,20 @@ And(/^there is a team named "([^"]*)" playing "([^"]*)"$/) do |team_name, quiz_n
   quiz = Quiz.find_by(name: quiz_name)
   FactoryGirl.create(:team, name: team_name, quiz: quiz)
 end
+
+When(/^"([^"]*)" is looking at the quiz page for "([^"]*)"$/) do |team_name, quiz_name|
+    steps %q{
+      Given there is a "team_id" cookie set to "#{team_name}"
+      And I switch to a new window
+      And I am on the quiz page for "Trivia"
+    }
+end
+
+Then(/^"([^"]*)" should see "([^"]*)"$/) do |team_name, content|
+  steps %q{
+    Given there is a "team_id" cookie set to "#{team_name}"
+    And I switch to a new window
+    And I am on the quiz page for "Trivia"
+  }
+  expect(page).to have_content content
+end

--- a/features/step_definitions/quiz_steps.rb
+++ b/features/step_definitions/quiz_steps.rb
@@ -17,7 +17,7 @@ Given(/^I receive the first question$/) do
     When I am on the quiz page for "Trivia"
     And I switch to a new window
     And I am on the quizmaster page for "Trivia"
-    When I press the "Send" button for question "1"
+    When I press the "Send" button for question "What is 2+2?"
     And I switch to window "1"
   }
 end

--- a/features/step_definitions/quizmaster_steps.rb
+++ b/features/step_definitions/quizmaster_steps.rb
@@ -3,6 +3,13 @@ When(/^I press the "([^"]*)" button for question "([^"]*)"$/) do |button, questi
   within("#question#{question.id}") { click_link_or_button button }
 end
 
+When(/^I press the correct button for question "([^"]*)"$/) do |question|
+  question = Question.find_by(body: question)
+  find("#correct_button_#{question.id}").trigger('click')
+  # click_link_or_button "#correct_button_#{question.id}"
+  # within("#question#{question.id}") { click_link_or_button button }
+end
+
 Then(/^I should be on the correction page for "([^"]*)"$/) do |question|
   question = Question.find_by(body: question)
   expect(current_path).to eq "/quizmaster/quiz/answers/#{question.id}"

--- a/features/step_definitions/quizmaster_steps.rb
+++ b/features/step_definitions/quizmaster_steps.rb
@@ -6,8 +6,6 @@ end
 When(/^I press the correct button for question "([^"]*)"$/) do |question|
   question = Question.find_by(body: question)
   find("#correct_button_#{question.id}").trigger('click')
-  # click_link_or_button "#correct_button_#{question.id}"
-  # within("#question#{question.id}") { click_link_or_button button }
 end
 
 Then(/^I should be on the correction page for "([^"]*)"$/) do |question|

--- a/features/step_definitions/quizmaster_steps.rb
+++ b/features/step_definitions/quizmaster_steps.rb
@@ -1,6 +1,6 @@
-When(/^I press the "([^"]*)" button for question "([^"]*)"$/) do |button, position|
-  index = position.to_i - 1
-  within("#question#{index}") { click_link_or_button button }
+When(/^I press the "([^"]*)" button for question "([^"]*)"$/) do |button, question|
+  question = Question.find_by(body: question)
+  within("#question#{question.id}") { click_link_or_button button }
 end
 
 Then(/^I should be on the correction page for "([^"]*)"$/) do |question|

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -10,3 +10,10 @@ end
 at_exit do
   RedisTest.stop
 end
+
+After '@javascript' do
+  Capybara.send('session_pool').each do |_, session|
+    next unless session.driver.is_a?(Capybara::Poltergeist::Driver)
+    session.driver.restart
+  end
+end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Team, type: :model do
   describe 'DB table' do
     it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :is_winner }
     it { is_expected.to belong_to :quiz }
     it { is_expected.to have_many :answers }
   end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/132561705

Changes proposed in this pull request:
- Create `results` page for Quizmaster
- Results page includes `Send Results` button, triggers Action Cable that sends a message about the winner
- Add `is_winner` attribute to Teams, when Quizmaster sends results, this attribute is updated with the Team that has the highest score

What I have learned working on this feature: 
- How to sort hashes by key values
- That javascript drivers are weird and complex

Screenshots: 
![screen shot 2016-10-23 at 9 49 56 am](https://cloud.githubusercontent.com/assets/20141428/19624782/196fedfc-9906-11e6-8494-72f1bbc693be.png)


Ready for review!
