### PR TITLE
adds line-height 50 px to linkbutton

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -59,6 +59,7 @@ body {
 .btn-sq-sm {
   width: 50px !important;
   height: 50px !important;
+  line-height: 50px;
   padding:0;
 }
 #send_question { display: inline-block; float:right;}


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/132958967

Changes proposed in this pull request:
- line-height 50px on the link that looks like a button

What I have learned working on this feature: 
- One change per PR. If you did more than one change its hard to know what broke stuff. 

Screenshots: 
<img width="92" alt="skarmavbild 2016-10-23 kl 08 23 29" src="https://cloud.githubusercontent.com/assets/7266909/19624520/066b8ae2-98fa-11e6-9e8a-270f3fa7ac75.png">


Ready for review!

