### PR TITLE
Send buttons stay "sent", Quiz stays "started"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -94,9 +94,9 @@ body {
   float: right;
   display: none;
 }
-#correct {
-  display: none;
-}
+// #correct {
+//   display: none;
+// }
 
 .links {
   margin: 2%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -94,9 +94,9 @@ body {
   float: right;
   display: none;
 }
-// #correct {
-//   display: none;
-// }
+#correct {
+  display: none;
+}
 
 .links {
   margin: 2%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,10 +57,7 @@ body {
   font-size:35px;
 }
 .btn-sq-sm {
-  // width: 50px !important;
-
   max-height: 50px;
-  // line-height: 50px;
   padding-right:5px;
   padding-left:5px;
   font-size: 130%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,10 +57,13 @@ body {
   font-size:35px;
 }
 .btn-sq-sm {
-  width: 50px !important;
-  height: 50px !important;
-  line-height: 50px;
-  padding:0;
+  // width: 50px !important;
+
+  max-height: 50px;
+  // line-height: 50px;
+  padding-right:5px;
+  padding-left:5px;
+  font-size: 130%;
 }
 #send_question { display: inline-block; float:right;}
 .question p {

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -1,10 +1,8 @@
 class Quizmaster::QuizzesController < ApplicationController
-  before_action :get_quiz, only: [:show,
-                                  :start_quiz,
-                                  :send_question,
-                                  :results,
-                                  :send_results,
-                                  :reset_quiz]
+  before_action :get_quiz, except: [:correct_answers,
+                                    :broadcast_content,
+                                    :mark_answers,
+                                    :get_winner_message]
 
   def show
     @questions = @quiz.questions.sort

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -1,16 +1,19 @@
 class Quizmaster::QuizzesController < ApplicationController
-  before_action :get_quiz, only: [:show, :start_quiz, :send_question, :results, :send_results]
+  before_action :get_quiz, only: [:show,
+                                  :start_quiz,
+                                  :send_question,
+                                  :results,
+                                  :send_results,
+                                  :reset_quiz]
 
   def show
     @questions = @quiz.questions.sort
   end
 
   def start_quiz
-    # @questions = @quiz.questions
     content = {message: params[:message], welcome: params[:welcome], quiz_id: params[:id]}
     BroadcastMessageJob.perform_now(content)
     @quiz.update_attribute(:is_started, true)
-    # render :show
   end
 
   def send_question
@@ -27,11 +30,7 @@ class Quizmaster::QuizzesController < ApplicationController
   end
 
   def reset_quiz
-    @quiz = Quiz.find(params[:id])
-    @quiz.is_started = false
-    @quiz.questions.each do |question|
-      question.update_attribute(:is_sent, false)
-    end
+    @quiz.reset_quiz_actions
     @questions = @quiz.questions.sort
     render :show
   end

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -9,7 +9,8 @@ class Quizmaster::QuizzesController < ApplicationController
     # @questions = @quiz.questions
     content = {message: params[:message], welcome: params[:welcome], quiz_id: params[:id]}
     BroadcastMessageJob.perform_now(content)
-    render :show
+    @quiz.update_attribute(:is_started, true)
+    # render :show
   end
 
   def send_question

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -25,6 +25,16 @@ class Quizmaster::QuizzesController < ApplicationController
     head :ok
   end
 
+  def reset_quiz
+    @quiz = Quiz.find(params[:id])
+    @quiz.is_started = false
+    @quiz.questions.each do |question|
+      question.update_attribute(:is_sent, false)
+    end
+    @questions = @quiz.questions.sort
+    render :show
+  end
+
   def correct_answers
     @question = Question.find(params[:id])
     render :answers

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -2,11 +2,11 @@ class Quizmaster::QuizzesController < ApplicationController
   before_action :get_quiz, only: [:show, :start_quiz, :send_question, :results, :send_results]
 
   def show
-    @questions = @quiz.questions
+    @questions = @quiz.questions.sort
   end
 
   def start_quiz
-    @questions = @quiz.questions
+    # @questions = @quiz.questions
     content = {message: params[:message], welcome: params[:welcome], quiz_id: params[:id]}
     BroadcastMessageJob.perform_now(content)
     render :show
@@ -16,6 +16,7 @@ class Quizmaster::QuizzesController < ApplicationController
     question = Question.find(params[:question_id])
     content = {question: question.body, index: params[:index], quiz_id: params[:id], question_id: params[:question_id], team_id: cookies['team_id']}
     broadcast_content(content)
+    question.update_attribute(:is_sent, true)
   end
 
   def send_results

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,4 +2,12 @@ class Question < ApplicationRecord
   validates_presence_of :body, :answer, :quiz_id
   belongs_to :quiz
   has_many :answers
+
+  def is_sent?
+    if self.is_sent == true
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,10 +4,7 @@ class Question < ApplicationRecord
   has_many :answers
 
   def is_sent?
-    if self.is_sent == true
-      true
-    else
-      false
-    end
+    self.is_sent
   end
+
 end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -18,6 +18,7 @@ class Quiz < ApplicationRecord
     self.update_attribute(:is_started, false)
     self.questions.each do |question|
       question.update_attribute(:is_sent, false)
+      question.answers.destroy_all
     end
   end
 

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -14,6 +14,13 @@ class Quiz < ApplicationRecord
     scores.sort_by! {|score, points| points}
   end
 
+  def reset_quiz_actions
+    self.update_attribute(:is_started, false)
+    self.questions.each do |question|
+      question.update_attribute(:is_sent, false)
+    end
+  end
+
   private
 
   def generate_random_code

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -22,6 +22,14 @@ class Quiz < ApplicationRecord
     end
   end
 
+  def is_started?
+    if self.is_started == true
+      true
+    else
+      false
+    end
+  end
+
   private
 
   def generate_random_code

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -23,11 +23,7 @@ class Quiz < ApplicationRecord
   end
 
   def is_started?
-    if self.is_started == true
-      true
-    else
-      false
-    end
+    self.is_started
   end
 
   private

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -26,6 +26,7 @@
               = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
 
   = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'
+  = link_to 'Reset the Quiz', quizmaster_reset_quiz_path(@quiz), class: 'btn-sq-sm btn-success links'
 
 
 :javascript

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -18,10 +18,12 @@
           = hidden_field_tag 'welcome', false
           = hidden_field_tag 'index', (index.to_i + 1)
           = hidden_field_tag 'question_id', question.id
-          .btn-group#send
-            = submit_tag 'Send', id: "send_button#{question.id}", class: 'btn btn-sq-sm btn-success'
-          .btn-group#correct
-            = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
+          - if question.is_sent == false
+            .btn-group#send
+              = submit_tag 'Send', id: "send_button#{question.id}", class: 'btn btn-sq-sm btn-success'
+          - else
+            .btn-group#correct
+              = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
 
   = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'
 

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -32,7 +32,7 @@
             = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
 
   = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'
-  = link_to 'Reset the Quiz', quizmaster_reset_quiz_path(@quiz), class: 'btn-sq-sm btn-success links'
+  = link_to 'Reset the Quiz', quizmaster_reset_quiz_path(@quiz), class: 'btn-sq-sm btn-success links', data: {confirm: 'Are you sure? Resetting the quiz will delete all answers.'}
 
 
 :javascript

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -1,11 +1,15 @@
 .big-box
   %h1= @quiz.name
   %h3= @quiz.code
-  .activate_quiz
-    = form_tag quizmaster_path(@quiz), id: 'start_quiz', remote: true do
-      = hidden_field_tag 'welcome', true
-      = text_field_tag 'message', nil, placeholder: 'Welcome message', class: 'form-control code'
-      = submit_tag 'Start the Quiz', id: 'start_button', class: 'btn btn-primary btn-lg btn-block'
+  - if @quiz.is_started == false
+    .activate_quiz
+      = form_tag quizmaster_path(@quiz), id: 'start_quiz', remote: true do
+        = hidden_field_tag 'welcome', true
+        = text_field_tag 'message', nil, placeholder: 'Welcome message', class: 'form-control code'
+        = submit_tag 'Start the Quiz', id: 'start_button', class: 'btn btn-primary btn-lg btn-block'
+  - else
+    .quiz_started_extra
+      %p You have started the quiz!
   .quiz_started
     %p You have started the quiz!
 
@@ -22,7 +26,7 @@
             .btn-group#send
               = submit_tag 'Send', id: "send_button#{question.id}", class: 'btn btn-sq-sm btn-success'
           - else
-            .btn-group#correctshow
+            .btn-group
               = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
           .btn-group#correct
             = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -1,7 +1,7 @@
 .big-box
   %h1= @quiz.name
   %h3= @quiz.code
-  - if @quiz.is_started == false
+  - unless @quiz.is_started?
     .activate_quiz
       = form_tag quizmaster_path(@quiz), id: 'start_quiz', remote: true do
         = hidden_field_tag 'welcome', true
@@ -22,7 +22,7 @@
           = hidden_field_tag 'welcome', false
           = hidden_field_tag 'index', (index.to_i + 1)
           = hidden_field_tag 'question_id', question.id
-          - if question.is_sent == false
+          - unless question.is_sent?
             .btn-group#send
               = submit_tag 'Send', id: "send_button#{question.id}", class: 'btn btn-sq-sm btn-success'
           - else

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -22,8 +22,10 @@
             .btn-group#send
               = submit_tag 'Send', id: "send_button#{question.id}", class: 'btn btn-sq-sm btn-success'
           - else
-            .btn-group#correct
+            .btn-group#correctshow
               = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
+          .btn-group#correct
+            = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
 
   = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'
   = link_to 'Reset the Quiz', quizmaster_reset_quiz_path(@quiz), class: 'btn-sq-sm btn-success links'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :quizmaster do
     resources :quiz, controller: :quizzes, only: [:show]
     post '/quiz/:id', controller: :quizzes, action: :start_quiz
+    get '/quiz/reset/:id', controller: :quizzes, action: :reset_quiz, as: :reset_quiz
     post '/send_question', controller: :quizzes, action: :send_question
     get 'quiz/answers/:id', controller: :quizzes, action: :correct_answers, as: :correct_answers
     get 'quiz/answers/mark/:id', controller: :quizzes, action: :mark_answers, as: :mark_answers

--- a/db/migrate/20161023154619_add_is_sent_to_questions.rb
+++ b/db/migrate/20161023154619_add_is_sent_to_questions.rb
@@ -1,0 +1,5 @@
+class AddIsSentToQuestions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :questions, :is_sent, :boolean, default: false
+  end
+end

--- a/db/migrate/20161023160023_add_is_started_to_quiz.rb
+++ b/db/migrate/20161023160023_add_is_started_to_quiz.rb
@@ -1,0 +1,5 @@
+class AddIsStartedToQuiz < ActiveRecord::Migration[5.0]
+  def change
+    add_column :quizzes, :is_started, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161022175950) do
+ActiveRecord::Schema.define(version: 20161023154619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,9 +29,10 @@ ActiveRecord::Schema.define(version: 20161022175950) do
   create_table "questions", force: :cascade do |t|
     t.string   "body"
     t.string   "answer"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
     t.integer  "quiz_id"
+    t.boolean  "is_sent",    default: false
     t.index ["quiz_id"], name: "index_questions_on_quiz_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161023154619) do
+ActiveRecord::Schema.define(version: 20161023160023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,8 +39,9 @@ ActiveRecord::Schema.define(version: 20161023154619) do
   create_table "quizzes", force: :cascade do |t|
     t.string   "name"
     t.string   "code"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "is_started", default: false
   end
 
   create_table "teams", force: :cascade do |t|

--- a/features/quizmaster/running_quiz.feature
+++ b/features/quizmaster/running_quiz.feature
@@ -30,5 +30,7 @@ Scenario: I send multiple questions
 
 Scenario: Resetting the quiz
   Given I have sent the first question
+  And "Craft Academy" has answered question "What is 2+2?" with "Six"
   When I press the "Reset the Quiz" button
   Then I should not see "Correct"
+  And there should be "0" answers for "What is 2+2?"

--- a/features/quizmaster/running_quiz.feature
+++ b/features/quizmaster/running_quiz.feature
@@ -25,7 +25,7 @@ Scenario: I send multiple questions
   Given I have sent the first question
   And I click the "Correct" button
   When I click the "Back to Questions" link
-  And I wait
+  And I wait for the page to load
   And I should see "Correct"
 
 Scenario: Resetting the quiz

--- a/features/quizmaster/running_quiz.feature
+++ b/features/quizmaster/running_quiz.feature
@@ -20,3 +20,10 @@ Scenario: I send the first question
   When I press the "Send" button for question "What is 2+2?"
   And I switch to window "1"
   Then I should see "What is 2+2?"
+
+Scenario: I send multiple questions
+  Given I have sent the first question
+  And I click the "Correct" button
+  When I click the "Back to Questions" link
+  And I wait
+  And I click the "Correct" button

--- a/features/quizmaster/running_quiz.feature
+++ b/features/quizmaster/running_quiz.feature
@@ -33,4 +33,4 @@ Scenario: Resetting the quiz
   And "Craft Academy" has answered question "What is 2+2?" with "Six"
   When I press the "Reset the Quiz" button
   Then I should not see "Correct"
-  And there should be "0" answers for "What is 2+2?"
+  And there should be 0 answers for "What is 2+2?"

--- a/features/quizmaster/running_quiz.feature
+++ b/features/quizmaster/running_quiz.feature
@@ -26,4 +26,9 @@ Scenario: I send multiple questions
   And I click the "Correct" button
   When I click the "Back to Questions" link
   And I wait
-  And I click the "Correct" button
+  And I should see "Correct"
+
+Scenario: Resetting the quiz
+  Given I have sent the first question
+  When I press the "Reset the Quiz" button
+  Then I should not see "Correct"

--- a/features/step_definitions/answer_steps.rb
+++ b/features/step_definitions/answer_steps.rb
@@ -10,3 +10,8 @@ Given(/^"([^"]*)" has answered "([^"]*)" questions right$/) do |team_name, count
     FactoryGirl.create(:answer, team: team, is_correct: true)
   end
 end
+
+Then(/^there should be "([^"]*)" answers for "([^"]*)"$/) do |count, question_body|
+  question = Question.find_by(body: question_body)
+  expect(question.answers.count).to eq count.to_i
+end

--- a/features/step_definitions/answer_steps.rb
+++ b/features/step_definitions/answer_steps.rb
@@ -11,7 +11,7 @@ Given(/^"([^"]*)" has answered "([^"]*)" questions right$/) do |team_name, count
   end
 end
 
-Then(/^there should be "([^"]*)" answers for "([^"]*)"$/) do |count, question_body|
+Then(/^there should be (\d+) answers for "([^"]*)"$/) do |count, question_body|
   question = Question.find_by(body: question_body)
   expect(question.answers.count).to eq count.to_i
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -26,3 +26,7 @@ end
 When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, content|
   fill_in element, with: content
 end
+
+When(/^I wait$/) do
+  sleep(1)
+end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -27,6 +27,6 @@ When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, content|
   fill_in element, with: content
 end
 
-When(/^I wait$/) do
+When(/^I wait for the page to load$/) do
   sleep(1)
 end

--- a/features/step_definitions/quizmaster_steps.rb
+++ b/features/step_definitions/quizmaster_steps.rb
@@ -31,3 +31,10 @@ Then(/^"([^"]*)" should have "([^"]*)" correct (?:answer|answers)$/) do |team_na
   team = Team.find_by(name: team_name)
   expect(team.answers.where(is_correct: true).count).to eq count.to_i
 end
+
+Given(/^I have sent the first question$/) do
+  steps %{
+    Given I am on the quizmaster page for "Trivia"
+    And I press the "Send" button for question "What is 2+2?"
+  }
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Question, type: :model do
   describe 'DB table' do
     it { is_expected.to have_db_column :body }
     it { is_expected.to have_db_column :answer }
+    it { is_expected.to have_db_column :is_sent }
     it { is_expected.to belong_to :quiz }
     it { is_expected.to have_many :answers }
   end

--- a/spec/models/quiz_spec.rb
+++ b/spec/models/quiz_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Quiz, type: :model do
   describe 'DB table' do
     it { is_expected.to have_db_column :name }
     it { is_expected.to have_db_column :code }
+    it { is_expected.to have_db_column :is_started }
     it { is_expected.to have_many :questions }
   end
 

--- a/spec/models/quiz_spec.rb
+++ b/spec/models/quiz_spec.rb
@@ -18,4 +18,12 @@ RSpec.describe Quiz, type: :model do
       expect(FactoryGirl.create(:quiz)).to be_valid
     end
   end
+
+  describe 'instance methods' do
+    it 'should return true if quiz has been started' do
+      quiz = FactoryGirl.create(:quiz)
+      quiz.update_attribute(:is_started, true)
+      expect(quiz.is_started?).to eq true
+    end
+  end
 end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/132962683

Changes proposed in this pull request:
- Set `is_sent` attribute on Questions
- Set `is_started` attribute on Quiz
- Create `reset_quiz` functionality to set all Questions back to not-sent and Quiz to not-started
- Conditionally show send/correct buttons on Quiz page and the welcome message form/text
- Make the buttons a little more user-friendly / pretty

What I have learned working on this feature:
- I feel sure that @diraulo is going to give me a better idea of how to do the conditional shows on the Quiz page. It's ugly and I know it but it does work!

Screenshots:
![screen shot 2016-10-23 at 6 29 40 pm](https://cloud.githubusercontent.com/assets/20141428/19627760/3dd5a47c-994f-11e6-9fdd-6d6c0680f2fe.png)


Ready for review!