### PR TITLE
adds space above the white box

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@ $gray-dark:                 #03001C;
 @import url('https://fonts.googleapis.com/css?family=Creepster');
 html, body { height:100vh; margin:0; padding:0;}
 body {
+  padding-top:60px;
   background: #ffc501;
   background: -moz-linear-gradient(top, #ffc501 0%, #fe9600 100%);
   background: -webkit-gradient(linear,left top, left bottom, color-stop(0%, #ffc501), color-stop(100%, #fe9600));
@@ -116,4 +117,10 @@ body {
   display: block;
   float: right;
   padding: 1%;
+}
+
+@media screen and (min-width: 480px) {
+  body {
+    padding-top: 10px;
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -119,7 +119,7 @@ body {
   padding: 1%;
 }
 
-@media screen and (min-width: 480px) {
+@media (max-width: 480px) {
   body {
     padding-top: 10px;
   }


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/132998209

Changes proposed in this pull request:
- Padding top to body, 10 px on small screens and 60 px on large. 

What I have learned working on this feature: 
- margin on the box changed how the body/html was presented. Padding on body does not. 

Screenshots:
<img width="313" alt="skarmavbild 2016-10-24 kl 10 31 02" src="https://cloud.githubusercontent.com/assets/7266909/19638611/0526c08a-99d5-11e6-8854-620adec0b14d.png">
<img width="628" alt="skarmavbild 2016-10-24 kl 10 31 10" src="https://cloud.githubusercontent.com/assets/7266909/19638612/054f5022-99d5-11e6-9786-5f0c9c2bfd08.png">


Ready for review!

