### PR TITLE
Bring the numbers back to the player Quiz view

### DIFF
--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,4 +1,6 @@
 .answer_form
+  = data[:index]
+  \. 
   = data[:question]
   #info{data: {quiz_id: data[:quiz_id], question_id: data[:question_id], team_id: data[:team_id]}}
   = text_field_tag 'body', '', class: 'form-control code'

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -17,7 +17,7 @@
     - @questions.each_with_index do |question, index|
       .question{id: "question#{question.id}"}
         %p
-          = "#{index}."
+          = "#{index.to_i + 1}."
           = question.body
         = form_tag quizmaster_send_question_path, id: 'send_question', remote: true do
           = hidden_field_tag 'id', @quiz.id

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -16,7 +16,9 @@
   .questions
     - @questions.each_with_index do |question, index|
       .question{id: "question#{question.id}"}
-        %p= question.body
+        %p
+          = "#{index}."
+          = question.body
         = form_tag quizmaster_send_question_path, id: 'send_question', remote: true do
           = hidden_field_tag 'id', @quiz.id
           = hidden_field_tag 'welcome', false


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/132960953

Changes proposed in this pull request:
- Show index on Quizmaster Quiz page
- Show index on Team Quiz page

What I have learned working on this feature: 
- How to get rid of white space in haml. By using godforsaken string interpolation (honestly, I hate haml)

Screenshots:
![screen shot 2016-10-24 at 12 38 19 pm](https://cloud.githubusercontent.com/assets/20141428/19642710/ca2033ba-99e6-11e6-9341-6be6f48ab259.png)
![screen shot 2016-10-24 at 12 38 57 pm](https://cloud.githubusercontent.com/assets/20141428/19642737/ee442c06-99e6-11e6-9a4e-22ff9c073c62.png)


Ready for review!