### PR TITLE
Fix answer methods so that teams are actually sending their id with answers

### DIFF
--- a/app/channels/quiz_channel.rb
+++ b/app/channels/quiz_channel.rb
@@ -15,6 +15,5 @@ class QuizChannel < ApplicationCable::Channel
     Answer.create(body: params[:answer],
                   question: question,
                   team: team)
-    BroadcastMessageJob.perform_now({message: 'Answer submitted!', welcome: 'true'})
   end
 end

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -16,7 +16,7 @@ class Quizmaster::QuizzesController < ApplicationController
 
   def send_question
     question = Question.find(params[:question_id])
-    content = {question: question.body, index: params[:index], quiz_id: params[:id], question_id: params[:question_id], team_id: cookies['team_id']}
+    content = {question: question.body, index: params[:index], quiz_id: params[:id], question_id: params[:question_id]}
     broadcast_content(content)
     question.update_attribute(:is_sent, true)
   end

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -10,6 +10,7 @@
     %hr/
     #message.question_container
       Questions will appear here.
+    #team_id{data: {team_id: cookies['team_id']}}
 
 :javascript
   $(document).ready(function () {
@@ -18,13 +19,14 @@
       $this = $(this);
       dataset = $this.find('#info')
       quiz = dataset.data().quizId;
-      team = dataset.data().teamId;
+      team = $this.find('#team_id').data().teamId
       question = dataset.data().questionId;
       answer = $this.find('#body');
+
       if ($.trim(answer.val()).length >= 1) {
         App.quiz.submitAnswer({answer: answer.val(), team_id: team, quiz_id: quiz, question_id: question});
         $('.answer_form').hide();
-        $('.wait').show();
+        $('.answer_submitted').show();
       } else {
         $('#message').append('WTF Dude?!?')
       }

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -10,3 +10,24 @@
     %hr/
     #message.question_container
       Questions will appear here.
+
+:javascript
+  $(document).ready(function () {
+    this.submitAnswer = function () {
+      var $this, dataset, quiz, answer, question, team ;
+      $this = $(this);
+      dataset = $this.find('#info')
+      quiz = dataset.data().quizId;
+      team = dataset.data().teamId;
+      question = dataset.data().questionId;
+      answer = $this.find('#body');
+      if ($.trim(answer.val()).length >= 1) {
+        App.quiz.submitAnswer({answer: answer.val(), team_id: team, quiz_id: quiz, question_id: question});
+        $('.answer_form').hide();
+        $('.wait').show();
+      } else {
+        $('#message').append('WTF Dude?!?')
+      }
+      return false;
+    };
+  });

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -1,5 +1,10 @@
 .answer_form
   = data[:question]
-  #info{data: {quiz_id: data[:quiz_id], question_id: data[:question_id], team_id: data[:team_id]}}
+  #info{data: {quiz_id: data[:quiz_id], question_id: data[:question_id]}}
   = text_field_tag 'body', '', class: 'form-control code'
   = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block', onclick: 'submitAnswer();'
+.answer_submitted
+  Answer submitted!
+
+:javascript
+  $('.answer_submitted').hide();

--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -3,27 +3,3 @@
   #info{data: {quiz_id: data[:quiz_id], question_id: data[:question_id], team_id: data[:team_id]}}
   = text_field_tag 'body', '', class: 'form-control code'
   = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block', onclick: 'submitAnswer();'
-.wait
-  The next question is coming soon!
-
-:javascript
-  $(document).ready(function () {
-    $('.wait').hide();
-    this.submitAnswer = function () {
-      var $this, dataset, quiz, answer, question, team ;
-      $this = $(this);
-      dataset = $this.find('#info')
-      quiz = dataset.data().quizId;
-      team = dataset.data().teamId;
-      question = dataset.data().questionId;
-      answer = $this.find('#body');
-      if ($.trim(answer.val()).length >= 1) {
-        App.quiz.submitAnswer({answer: answer.val(), team_id: team, quiz_id: quiz, question_id: question});
-        $('.answer_form').hide();
-        $('.wait').show();
-      } else {
-        $('#message').append('WTF Dude?!?')
-      }
-      return false;
-    };
-  });


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/133027935
Changes proposed in this pull request:
- Extract `_question` javascript to main Quiz page for teams
- Implement and read hidden div with `cookie['team_id']`
- Send team id with answer submissions
- Remove 'Answer submitted!' broadcast blast that was replacing every team's question partial with 'Answer submitted!'

What I have learned working on this feature: 
- Cookies are not available in partials
- Javascript can see the parent and the partial, and can be used to grab info from both pieces

Ready for review!