### PR TITLE
Error handle code page

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -11,7 +11,12 @@ class GamesController < ApplicationController
 
   def access_quiz
     quiz = Quiz.find_by(code: params[:code])
-    redirect_to quiz_path(quiz)
+    if quiz.nil?
+      flash.now[:notice] = "Invalid code. Talk to your Quizmaster."
+      render :index
+    else
+      redirect_to quiz_path(quiz)
+    end
   end
 
   def create_team

--- a/app/views/games/index.html.haml
+++ b/app/views/games/index.html.haml
@@ -1,4 +1,5 @@
 .box
+  %h4= notice
   %h1 Play the game
   = form_tag access_quiz_path, method: :post do
     = text_field_tag :code, nil, placeholder: 'Enter your code', class: 'form-control code'

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -19,7 +19,6 @@ Feature: As a Team
   Scenario: I put in the wrong code
     Given I am on the quiz "landing" page
     And I enter a bad code
-    Then I should be on the quiz "landing" page
     And I should see "Invalid code. Talk to your Quizmaster."
 
   Scenario: Access quiz and subscribe to channel

--- a/features/player/access_quiz.feature
+++ b/features/player/access_quiz.feature
@@ -16,6 +16,12 @@ Feature: As a Team
     And I should see "Welcome to quiz: Trivia"
     And I should see a Create Team form
 
+  Scenario: I put in the wrong code
+    Given I am on the quiz "landing" page
+    And I enter a bad code
+    Then I should be on the quiz "landing" page
+    And I should see "Invalid code. Talk to your Quizmaster."
+
   Scenario: Access quiz and subscribe to channel
     Given there is a "team_id" cookie set to "Craft Academy"
     Given I am on the quiz "landing" page

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -5,14 +5,6 @@ Given(/^I am on the quiz "([^"]*)" page$/) do |page|
   end
 end
 
-Then(/^I should be on the quiz "([^"]*)" page$/) do |page|
-  case page
-  when 'landing'
-    path = quiz_index_path
-  end
-  expect(current_path).to eq path
-end
-
 And(/^I enter the code for "([^"]*)"$/) do |quiz|
   quiz = Quiz.find_by(name: quiz)
   fill_in :code, with: quiz.code

--- a/features/step_definitions/player_steps.rb
+++ b/features/step_definitions/player_steps.rb
@@ -5,9 +5,22 @@ Given(/^I am on the quiz "([^"]*)" page$/) do |page|
   end
 end
 
+Then(/^I should be on the quiz "([^"]*)" page$/) do |page|
+  case page
+  when 'landing'
+    path = quiz_index_path
+  end
+  expect(current_path).to eq path
+end
+
 And(/^I enter the code for "([^"]*)"$/) do |quiz|
   quiz = Quiz.find_by(name: quiz)
   fill_in :code, with: quiz.code
+  click_link_or_button 'Submit'
+end
+
+Given(/^I enter a bad code$/) do
+  fill_in :code, with: 'nonsense'
   click_link_or_button 'Submit'
 end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/133082945

Changes proposed in this pull request:
- Create a conditional to only show the `/quiz` page if the Team enters a valid code
- Flash message on index page alerting Teams that their code is invalid (if it is)

What I have learned working on this feature: [If you don't put anything here you are doing it wrong!]

Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]

Ready for review!
