### PR TITLE
Add ActionCable allowed request origins

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,6 +54,6 @@ Rails.application.configure do
 
   # Action Cable config
   config.action_cable.url = 'ws://localhost:3000/cable'
-
+  config.action_cable.allowed_request_origins = ["http://localhost:8100", 'http://localhost:3000']
 
 end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/133004177

Changes proposed in this pull request:
- Add ionic server :8000 as an accepted source in test

What I have learned working on this feature:
- Most of what I was doing on this one ended up in the Ionic app - everything except the one line to the accepted URLs, actually. But it's been a fun ride with this ActionCable business.

Ready for review!