### PR TITLE
CSS for admin results and question pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
  */
 $brand-primary:             #77477E;
 $brand-success:             #FFC501;
+$brand-warning:             #fe9600;
 $gray-dark:                 #03001C;
 
 @import 'bootstrap';
@@ -126,7 +127,7 @@ body {
 
 @media (max-width: 730px) {
   .question p {
-    font-size: 15px;
+    margin-top:10px;
     float:none;
     line-height:18px;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -63,13 +63,16 @@ body {
   padding-left:5px;
   font-size: 130%;
 }
-#send_question { display: inline-block; float:right;}
+#send_question {
+  display: inline-block;
+  float:right;
+}
 .question p {
   font-size: 20px;
   float:left;
-  min-height:50px;
-  line-height: 50px;
-  margin-right: 51px;
+  line-height: 45px;
+  margin-right: 100px;
+  margin-bottom: 10px;
 }
 .question {
   padding-top: 10px;
@@ -100,27 +103,41 @@ body {
 }
 
 .links {
-  margin: 2%;
-  padding: 1%;
-  font-size: 110%;
-  color: #ffffff;
-  align-self: center;
-  text-align: center;
+  margin-top: 10px;
 }
 
 .score {
   font-size: 130%;
   font-weight: bold;
-  background-color: #ffc501;
+  background-color: #77477E;
   color: #fff;
-  max-width: 30px;
+  max-width: 50px;
   display: block;
   float: right;
-  padding: 1%;
+  padding: 5px 10px;
 }
+
 
 @media (max-width: 480px) {
   body {
     padding-top: 10px;
   }
+}
+
+@media (max-width: 730px) {
+  .question p {
+    font-size: 15px;
+    float:none;
+    line-height:18px;
+  }
+  .btn-sq-sm {
+    width:100% !important;
+  }
+  .btn-group {
+    width:100% !important;
+  }
+  #send_question {
+    width:100% !important;
+  }
+
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -114,7 +114,7 @@ body {
   max-width: 50px;
   display: block;
   float: right;
-  padding: 5px 10px;
+  padding: 7px 14px;
 }
 
 

--- a/app/views/quizmaster/quizzes/results.html.haml
+++ b/app/views/quizmaster/quizzes/results.html.haml
@@ -1,12 +1,12 @@
 .big-box
   %h1= @quiz.name
-
   .results_div
     - @quiz.teams.each do |team|
-      = team.name
-      .score{class: 'score'}
-        = team.answers.where(is_correct: true).count
-      %hr/
+      .question
+        %p
+          = team.name
+        .score{class: 'score'}
+          = team.answers.where(is_correct: true).count
   .links
     = link_to 'Send Results', quizmaster_send_results_path(@quiz), method: :post, remote: true, class: 'btn btn-primary', id: 'send_results', onclick:"javascript:$(this).text('Resend Results');"
     = link_to 'Back to Questions', quizmaster_quiz_path(@quiz), class: 'btn btn-success'

--- a/app/views/quizmaster/quizzes/results.html.haml
+++ b/app/views/quizmaster/quizzes/results.html.haml
@@ -7,7 +7,6 @@
       .score{class: 'score'}
         = team.answers.where(is_correct: true).count
       %hr/
-  %divr
-    = link_to 'Send Results', quizmaster_send_results_path(@quiz), method: :post, remote: true, class: 'btn-sq-sm btn-success links', id: 'send_results', onclick:"javascript:$(this).text('Resend Results');"
-  %divr
-    = link_to 'Back to Questions', quizmaster_quiz_path(@quiz), class: 'btn-sq-sm btn-success links'
+  .links
+    = link_to 'Send Results', quizmaster_send_results_path(@quiz), method: :post, remote: true, class: 'btn btn-primary', id: 'send_results', onclick:"javascript:$(this).text('Resend Results');"
+    = link_to 'Back to Questions', quizmaster_quiz_path(@quiz), class: 'btn btn-success'

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -32,9 +32,9 @@
               = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
           .btn-group#correct
             = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'
-
-  = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn-sq-sm btn-success links'
-  = link_to 'Reset the Quiz', quizmaster_reset_quiz_path(@quiz), class: 'btn-sq-sm btn-success links', data: {confirm: 'Are you sure? Resetting the quiz will delete all answers.'}
+  .links
+    = link_to 'Results', quizmaster_results_path(@quiz), class: 'btn btn-primary'
+    = link_to 'Reset the Quiz', quizmaster_reset_quiz_path(@quiz), class: 'btn btn-success', data: {confirm: 'Are you sure? Resetting the quiz will delete all answers.'}
 
 
 :javascript

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -26,7 +26,7 @@
           = hidden_field_tag 'question_id', question.id
           - unless question.is_sent?
             .btn-group#send
-              = submit_tag 'Send', id: "send_button#{question.id}", class: 'btn btn-sq-sm btn-success'
+              = submit_tag 'Send', id: "send_button#{question.id}", class: 'btn btn-sq-sm btn-warning'
           - else
             .btn-group
               = link_to 'Correct', quizmaster_correct_answers_path(question), id: "correct_button_#{question.id}", class: 'btn btn-sq-sm btn-success'


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/133083071

Changes proposed in this pull request:
- use the question css for the rows instead of HR. 
- responsive layout of results and question page

What I have learned working on this feature: 
- The team needed my skillz ;)

Screenshots: 
<img width="670" alt="skarmavbild 2016-10-26 kl 16 54 52" src="https://cloud.githubusercontent.com/assets/7266909/19731283/3f05d308-9b9d-11e6-9095-bfe6df646188.png">
<img width="456" alt="skarmavbild 2016-10-26 kl 16 56 24" src="https://cloud.githubusercontent.com/assets/7266909/19731285/3f2bbd5c-9b9d-11e6-811b-86dc36c9276f.png">


Ready for review!
