### PR TITLE
Move team_id cookie to access_quiz method

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -5,7 +5,7 @@ class GamesController < ApplicationController
   end
 
   def show
-    @team = Team.find(cookies['team_id']) unless cookies['team_id'].nil?
+    @team = Team.find(cookies['team_id']) unless cookies['team_id'].nil? || cookies['team_id'].empty?
     render :show, locals: {message: "Welcome to quiz: #{@quiz.name}"}
   end
 
@@ -15,6 +15,8 @@ class GamesController < ApplicationController
       flash.now[:notice] = "Invalid code. Talk to your Quizmaster."
       render :index
     else
+      cookies['team_id'] = nil
+      cookies['quiz_id'] = quiz.id
       redirect_to quiz_path(quiz)
     end
   end

--- a/app/views/games/show.html.haml
+++ b/app/views/games/show.html.haml
@@ -1,6 +1,6 @@
 .big-box
   %h1= message
-  - if cookies['team_id'].nil?
+  - if cookies['team_id'].nil? || cookies['team_id'].empty?
     %p Enter your teamname and press the button!
     = form_tag quiz_create_team_path(@quiz), id: 'create_team', remote: true do
       = text_field_tag 'team[name]', nil, placeholder: 'Team Name', class: 'form-control code'


### PR DESCRIPTION
Cookies were being set incorrectly, so we moved them to `access_quiz` method. This required an additional check for `.empty?` and not just `.nil?` -> seems to be something about the cookies going through the browser that translates `nil` to `""`.