### PR TITLE
Q&A in winner partial, styling things, error handle some links

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,6 +36,9 @@ body {
 .logo{
   width: 200px;
 }
+.center {
+  text-align: center;
+}
 .big-box {
   margin: 0px auto;
   padding:20px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,9 @@ body {
 .center {
   text-align: center;
 }
+.top_space {
+  padding-top: 10px;
+}
 .big-box {
   margin: 0px auto;
   padding:20px;

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -32,7 +32,7 @@ class Quizmaster::QuizzesController < ApplicationController
 
   def send_results
     list = @quiz.get_scores
-    content = {winner: get_winner, list: list, welcome: 'false', quiz_id: @quiz.id}
+    content = {winner: get_winner, list: list, welcome: 'false', quiz: @quiz}
     BroadcastWinnerJob.perform_now(content)
     head :ok
   end

--- a/app/controllers/quizmaster/quizzes_controller.rb
+++ b/app/controllers/quizmaster/quizzes_controller.rb
@@ -11,6 +11,7 @@ class Quizmaster::QuizzesController < ApplicationController
   end
 
   def index
+    redirect_to root_path unless current_user
   end
 
   def add_quiz

--- a/app/jobs/broadcast_winner_job.rb
+++ b/app/jobs/broadcast_winner_job.rb
@@ -2,7 +2,7 @@ class BroadcastWinnerJob < ApplicationJob
   queue_as :default
 
   def perform(data)
-    ActionCable.server.broadcast "quiz_channel_#{data[:quiz_id]}", create_partial(data)
+    ActionCable.server.broadcast "quiz_channel_#{data[:quiz].id}", create_partial(data)
   end
 
   def create_partial(data)

--- a/app/views/games/index.html.haml
+++ b/app/views/games/index.html.haml
@@ -1,4 +1,6 @@
 .box
+  %p.notice= notice
+  %p.alert= alert
   %h1 Play the game
   = form_tag access_quiz_path, method: :post do
     = text_field_tag :code, nil, placeholder: 'Enter your code', class: 'form-control code'

--- a/app/views/games/index.html.haml
+++ b/app/views/games/index.html.haml
@@ -1,11 +1,14 @@
 .box
-  %p.notice= notice
-  %p.alert= alert
+
   %h1 Play the game
   = form_tag access_quiz_path, method: :post do
     = text_field_tag :code, nil, placeholder: 'Enter your code', class: 'form-control code'
     = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block'
-    - if current_user
-      = link_to 'Quizmaster Dashboard', quizmaster_dashboard_path
-    - else
-      = link_to "Log in as Quizmaster", new_user_session_path
+  %span
+    .top_space.center
+      - if current_user
+        = link_to 'Quizmaster Dashboard', quizmaster_dashboard_path
+      - else
+        = link_to "Log in as Quizmaster", new_user_session_path
+  %span.notice= notice
+  %span.alert= alert

--- a/app/views/games/index.html.haml
+++ b/app/views/games/index.html.haml
@@ -3,4 +3,7 @@
   = form_tag access_quiz_path, method: :post do
     = text_field_tag :code, nil, placeholder: 'Enter your code', class: 'form-control code'
     = submit_tag 'Submit', class: 'btn btn-primary btn-lg btn-block'
-    = link_to "Log in as Quizmaster", new_user_session_path
+    - if current_user
+      = link_to 'Quizmaster Dashboard', quizmaster_dashboard_path
+    - else
+      = link_to "Log in as Quizmaster", new_user_session_path

--- a/app/views/games/index.html.haml
+++ b/app/views/games/index.html.haml
@@ -10,5 +10,3 @@
         = link_to 'Quizmaster Dashboard', quizmaster_dashboard_path
       - else
         = link_to "Log in as Quizmaster", new_user_session_path
-  %span.notice= notice
-  %span.alert= alert

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,8 +9,6 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track' => 'reload'
   %body
-    %p.notice= notice
-    %p.alert= alert
     = yield
     .logo.col-center-block
       = link_to image_tag('logo.png'), 'http://www.craftacademy.se', target: '_blank'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,6 +9,12 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track' => 'reload'
   %body
+    - unless notice.nil?
+      .box
+        %span.notice= notice
+    - unless alert.nil?
+      .box
+        %span.alert= alert
     = yield
     .logo.col-center-block
       = link_to image_tag('logo.png'), 'http://www.craftacademy.se', target: '_blank'

--- a/app/views/partials/_winner.html.haml
+++ b/app/views/partials/_winner.html.haml
@@ -1,3 +1,14 @@
 .results
   - data[:list].reverse.each do |team|
-    %p #{team[:team].name} got #{team[:score]} points
+    %p #{team[:team].name}: #{team[:score]}
+%span{id: 'see_answers', class: 'btn btn-primary btn-lg btn-block'} See Answers
+.results{id: 'answers'}
+  Answers!
+
+:javascript
+  $('#answers').hide();
+  $(document).on('click', '#see_answers', function(e)
+    {
+      $('#answers').show();
+      $('#see_answers').hide();
+    });

--- a/app/views/partials/_winner.html.haml
+++ b/app/views/partials/_winner.html.haml
@@ -3,9 +3,12 @@
     %p #{team[:team].name}: #{team[:score]}
 %span{id: 'see_answers', class: 'btn btn-primary btn-lg btn-block'} See Answers
 .results{id: 'answers'}
-  - data[:quiz].questions.each do |question|
-    = question.body
+  - data[:quiz].questions.each_with_index do |question, index|
+    %span{style: "font-weight: bold"}
+      = "#{index.to_i + 1}."
+      = question.body
     %br/
+    Answer:
     = question.answer
     %hr/
 

--- a/app/views/partials/_winner.html.haml
+++ b/app/views/partials/_winner.html.haml
@@ -3,7 +3,11 @@
     %p #{team[:team].name}: #{team[:score]}
 %span{id: 'see_answers', class: 'btn btn-primary btn-lg btn-block'} See Answers
 .results{id: 'answers'}
-  Answers!
+  - data[:quiz].questions.each do |question|
+    = question.body
+    %br/
+    = question.answer
+    %hr/
 
 :javascript
   $('#answers').hide();

--- a/app/views/quizmaster/quizzes/add_quiz.html.haml
+++ b/app/views/quizmaster/quizzes/add_quiz.html.haml
@@ -1,5 +1,4 @@
-.box
+.big-box
   %h1 Create a new quiz
 
   %p Here's where the form is going to be
-  

--- a/app/views/quizmaster/quizzes/answers.html.haml
+++ b/app/views/quizmaster/quizzes/answers.html.haml
@@ -1,5 +1,5 @@
 .big-box
-  .row
+  .row.center
     .col-sm-12.col-md-4
       %h4 Quizmaster
     .col-sm-12.col-md-4

--- a/app/views/quizmaster/quizzes/index.html.haml
+++ b/app/views/quizmaster/quizzes/index.html.haml
@@ -1,6 +1,5 @@
-
-.box
-  %h1 Dashboard
+.big-box
+  %h1 My Quizzes
 
   - current_user.quizzes.each do |quiz|
 

--- a/app/views/quizmaster/quizzes/results.html.haml
+++ b/app/views/quizmaster/quizzes/results.html.haml
@@ -1,5 +1,5 @@
 .big-box
-  .row
+  .row.center
     .col-sm-12.col-md-4
       %h4 Quizmaster
     .col-sm-12.col-md-4

--- a/app/views/quizmaster/quizzes/show.html.haml
+++ b/app/views/quizmaster/quizzes/show.html.haml
@@ -1,5 +1,5 @@
 .big-box
-  .row
+  .row.center
     .col-sm-12.col-md-4
       %h4 Quizmaster
     .col-sm-12.col-md-4

--- a/features/quizmaster/login.feature
+++ b/features/quizmaster/login.feature
@@ -3,7 +3,7 @@ Feature: As a Quizmaster
   I need to be able to Login.
 
 Background:
-Given there is a user with email "viktoria@quizmaster.com"
+Given there is a quizmaster with email "viktoria@quizmaster.com"
 
 Scenario: I Login
   Given I am on the quizmaster "Log in" page

--- a/features/quizmaster/view_dashboard.feature
+++ b/features/quizmaster/view_dashboard.feature
@@ -25,3 +25,8 @@ Scenario: I try to visit the quizmaster page without logging in
   Given I am not logged in
   When I am on the quizmaster "Dashboard" page
   Then I should be on the "index" page
+
+Scenario: I log in and see the correct link on index
+  Given I log in as "amber@quizmaster.com"
+  When I am on the quiz "landing" page
+  Then I should see "Quizmaster Dashboard"

--- a/features/quizmaster/view_dashboard.feature
+++ b/features/quizmaster/view_dashboard.feature
@@ -20,3 +20,8 @@ Scenario: Amber should not see my quizzes
   Given I log in as "amber@quizmaster.com"
   And I am on the quizmaster "Dashboard" page
   Then I should not see "General"
+
+Scenario: I try to visit the quizmaster page without logging in
+  Given I am not logged in
+  When I am on the quizmaster "Dashboard" page
+  Then I should be on the "index" page

--- a/features/quizmaster/view_results_page.feature
+++ b/features/quizmaster/view_results_page.feature
@@ -5,6 +5,10 @@ Feature: As a Quizmaster
 
 Background:
   Given there is a quiz called "Trivia"
+  And the following questions exist in "Trivia":
+    | body            | answer        |
+    | What is 2+2?    | Four          |
+    | Who is awesome? | Craft Academy |
   And there is a team named "Craft Academy" playing "Trivia"
   And there is a team named "Amber Rocks" playing "Trivia"
   And "Craft Academy" has answered "10" questions right
@@ -16,4 +20,8 @@ Scenario: I view and send results
   Then I should see "10"
   When "Amber Rocks" is looking at the quiz page for "Trivia"
   And I click the "Send Results" button
-  Then window 2 should see "Amber Rocks got 11 points Craft Academy got 10 points"
+  Then window 2 should see "Amber Rocks: 11 Craft Academy: 10"
+  When I click on "See Answers"
+  Then I should not see "See Answers"
+  And I should see "What is 2+2?"
+  And I should see "Four"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -39,6 +39,10 @@ When(/^I (?:press|click) the "([^"]*)" (?:button|link)$/) do |button|
   click_link_or_button button
 end
 
+When(/^I click on "([^"]*)"$/) do |element|
+  page.find(:xpath,"//*[text()='#{element}']").click
+end
+
 When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, content|
   fill_in element, with: content
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -27,6 +27,13 @@ Then(/^I should be on the Log in page$/) do
   expect(current_path).to eq new_user_session_path
 end
 
+Then(/^I should be on the "([^"]*)" page$/) do |page|
+  case page
+  when 'index'
+    expect(current_path).to eq root_path
+  end
+end
+
 
 When(/^I (?:press|click) the "([^"]*)" (?:button|link)$/) do |button|
   click_link_or_button button

--- a/features/step_definitions/quizmaster_steps.rb
+++ b/features/step_definitions/quizmaster_steps.rb
@@ -52,6 +52,9 @@ Given(/^I log in as "([^"]*)"$/) do |email|
   }
 end
 
+Given(/^I am not logged in$/) do
+  logout
+end
 
 Given(/^I am on the quizmaster "([^"]*)" page$/) do |page|
   case page

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -27,3 +27,7 @@ Capybara.register_server :puma do |app, port, host|
 end
 
 Capybara.server = :puma
+
+Warden.test_mode!
+World Warden::Test::Helpers
+After { Warden.test_reset! }


### PR DESCRIPTION
PT Story: None - just clicked around and found problems

Changes proposed in this pull request:
- Add questions and answers to winner partial
- Style flash messages
- Center quizmaster headers
- Conditionally show login on `index` page - otherwise it says `Quizmaster Dashboard`
- Error handle directly trying to access `/quizmaster` when not logged in
 
What I have learned working on this feature:
- How to add an event listener in JQuery

Screenshots:
![screen shot 2016-10-28 at 11 57 53 am](https://cloud.githubusercontent.com/assets/20141428/19802828/c855a6d8-9d05-11e6-8c12-39abfe5e6f1d.png)


Ready for review!
